### PR TITLE
feat: 기사님 찾기 페이지

### DIFF
--- a/src/app/(with-public)/mover-search/_components/DriverCard.tsx
+++ b/src/app/(with-public)/mover-search/_components/DriverCard.tsx
@@ -1,0 +1,37 @@
+import MoverProfile from '@/components/common/profile/MoverProfile';
+import MoveChip from '@/components/common/chips/MoveChip';
+
+export default function DriverCard() {
+  return (
+    <div className="flex items-center justify-center w-full h-[188px] lg:h-[230px] bg-white rounded-xl border border-gray-50 shadow-sm">
+      <div className='flex flex-col'>
+      {/* 서비스 태그 */}
+      <div className="flex items-center mb-2 gap-2">
+        <MoveChip type="SMALL" mini={false} />
+        <MoveChip type="DESIGNATED" mini={false} />
+      </div>
+
+
+      {/* 소개 문구 */}
+      <p className="text-14-semibold md:text-14-semibold lg:text-24-semibold text-gray-700 mb-3">
+        고객님의 물품을 안전하게 운송해 드립니다.
+      </p>
+
+      {/* MoverProfile 삽입 */}
+      <div className="w-[300px] h-[78px] md:w-[572px] lg:w-[907px] lg:h-[92px] box-border">
+        <MoverProfile
+          big={false}
+          isLiked={false}
+          handleLikedClick={() => console.log('좋아요 클릭')}
+          nickName="김코드"
+          favoriteCount={136}
+          averageReviewRating={5.0}
+          reviewCount={178}
+          career={7}
+          estimateCount={334}
+        />
+      </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-public)/mover-search/_components/DriverCard.tsx
+++ b/src/app/(with-public)/mover-search/_components/DriverCard.tsx
@@ -3,34 +3,33 @@ import MoveChip from '@/components/common/chips/MoveChip';
 
 export default function DriverCard() {
   return (
-    <div className="flex items-center justify-center w-full h-[188px] lg:h-[230px] bg-white rounded-xl border border-gray-50 shadow-sm">
-      <div className='flex flex-col'>
-      {/* 서비스 태그 */}
-      <div className="flex items-center mb-2 gap-2">
-        <MoveChip type="SMALL" mini={false} />
-        <MoveChip type="DESIGNATED" mini={false} />
-      </div>
+    <div className="flex items-center justify-center w-full h-48 lg:h-56 bg-white rounded-xl border border-gray-50 shadow-sm">
+      <div className="flex flex-col">
+        {/* 서비스 태그 */}
+        <div className="flex items-center mb-2 gap-2">
+          <MoveChip type="SMALL" mini={false} />
+          <MoveChip type="DESIGNATED" mini={false} />
+        </div>
 
+        {/* 소개 문구 */}
+        <p className="text-14-semibold md:text-14-semibold lg:text-24-semibold text-gray-700 mb-3">
+          고객님의 물품을 안전하게 운송해 드립니다.
+        </p>
 
-      {/* 소개 문구 */}
-      <p className="text-14-semibold md:text-14-semibold lg:text-24-semibold text-gray-700 mb-3">
-        고객님의 물품을 안전하게 운송해 드립니다.
-      </p>
-
-      {/* MoverProfile 삽입 */}
-      <div className="w-[300px] h-[78px] md:w-[572px] lg:w-[907px] lg:h-[92px] box-border">
-        <MoverProfile
-          big={false}
-          isLiked={false}
-          handleLikedClick={() => console.log('좋아요 클릭')}
-          nickName="김코드"
-          favoriteCount={136}
-          averageReviewRating={5.0}
-          reviewCount={178}
-          career={7}
-          estimateCount={334}
-        />
-      </div>
+        {/* MoverProfile 삽입 */}
+        <div className="w-72 h-20 md:w-[34rem] lg:w-[56rem] lg:h-24 box-border">
+          <MoverProfile
+            big={false}
+            isLiked={false}
+            handleLikedClick={() => console.log('좋아요 클릭')}
+            nickName="김코드"
+            favoriteCount={136}
+            averageReviewRating={5.0}
+            reviewCount={178}
+            career={7}
+            estimateCount={334}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/(with-public)/mover-search/_components/DriverList.tsx
+++ b/src/app/(with-public)/mover-search/_components/DriverList.tsx
@@ -1,0 +1,12 @@
+// components/DriverList.jsx
+import DriverCard from './DriverCard';
+
+export default function DriverList() {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <DriverCard key={i} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(with-public)/mover-search/_components/Dropdown.tsx
+++ b/src/app/(with-public)/mover-search/_components/Dropdown.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect, useRef, useState } from "react";
+import chevronDownBlackIcon from "@/assets/images/chevronDownBlackIcon.svg";
+import chevronDownBlueIcon from "@/assets/images/chevronDownBlueIcon.svg";
+import Image from "next/image";
+
+export interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+interface DropdownProps {
+  label: string;
+  options: DropdownOption[];
+  onSelect?: (option: DropdownOption) => void;
+  multiColumn?: boolean;
+}
+
+export default function Dropdown({ label, options, onSelect, multiColumn }: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState(label);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleSelect = (option: DropdownOption) => {
+    setSelected(option.label);
+    setIsOpen(false);
+    onSelect?.(option);
+  };
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      {/* 버튼 */}
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={`
+          flex flex-row justify-between items-center
+          w-[75px] lg:w-[328px] px-3 py-2 rounded-lg border text-14-regular text-left
+          ${multiColumn ? '' : 'w-auto lg:w-[328px]'}
+          ${isOpen
+            ? 'border-primary-blue-300 text-primary-blue-300 bg-primary-blue-50'
+            : 'border-gray-200  bg-white'}
+        `}
+      >
+        {selected}
+        <Image
+          src={isOpen ? chevronDownBlueIcon : chevronDownBlackIcon}
+          alt="드롭다운"
+          className="w-[20px] h-[20px]"
+        />
+      </button>
+
+      {/* 옵션 리스트 */}
+      {isOpen && (
+        <div
+          className={`
+            absolute z-10 mt-2 bg-white border border-gray-200 rounded-lg shadow-md
+            overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent
+            ${multiColumn ? 'w-[165px] h-[180px] lg:w-auto lg:h-[320px]' : ''}
+          `}
+        >
+          {multiColumn ? (
+            <div className="grid grid-cols-2 divide-x divide-dotted divide-gray-200 max-h-full">
+              {options.map((option) => (
+                <div
+                  key={option.value}
+                  onClick={() => handleSelect(option)}
+                  className="
+                    cursor-pointer hover:bg-gray-100 text-14-regular
+                    flex items-center justify-start
+                    w-[75px] h-[36px] lg:w-[164px] lg:h-[64px] px-2
+                  "
+                >
+                  {option.label}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div>
+              {options.map((option) => (
+                <div
+                  key={option.value}
+                  onClick={() => handleSelect(option)}
+                  className="
+                    cursor-pointer hover:bg-gray-100 text-14-regular
+                    flex items-center justify-start
+                    w-[89px] h-[36px] lg:w-[328px] lg:h-[64px] px-3
+                  "
+                >
+                  {option.label}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(with-public)/mover-search/_components/Dropdown.tsx
+++ b/src/app/(with-public)/mover-search/_components/Dropdown.tsx
@@ -45,19 +45,20 @@ export default function Dropdown({ label, options, onSelect, multiColumn }: Drop
       <button
         onClick={() => setIsOpen((prev) => !prev)}
         className={`
-          flex flex-row justify-between items-center
-          w-[75px] lg:w-[328px] px-3 py-2 rounded-lg border text-14-regular text-left
-          ${multiColumn ? '' : 'w-auto lg:w-[328px]'}
+          flex justify-between items-center
+          ${multiColumn ? '' : 'w-auto lg:w-80'}
+          px-3 py-2 rounded-lg border text-sm text-left
           ${isOpen
             ? 'border-primary-blue-300 text-primary-blue-300 bg-primary-blue-50'
-            : 'border-gray-200  bg-white'}
+            : 'border-gray-200 bg-white'}
+          w-20 lg:w-80
         `}
       >
         {selected}
         <Image
           src={isOpen ? chevronDownBlueIcon : chevronDownBlackIcon}
           alt="드롭다운"
-          className="w-[20px] h-[20px]"
+          className="w-5 h-5"
         />
       </button>
 
@@ -67,7 +68,7 @@ export default function Dropdown({ label, options, onSelect, multiColumn }: Drop
           className={`
             absolute z-10 mt-2 bg-white border border-gray-200 rounded-lg shadow-md
             overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent
-            ${multiColumn ? 'w-[165px] h-[180px] lg:w-auto lg:h-[320px]' : ''}
+            ${multiColumn ? 'w-40 h-44 lg:w-auto lg:h-80' : ''}
           `}
         >
           {multiColumn ? (
@@ -77,9 +78,9 @@ export default function Dropdown({ label, options, onSelect, multiColumn }: Drop
                   key={option.value}
                   onClick={() => handleSelect(option)}
                   className="
-                    cursor-pointer hover:bg-gray-100 text-14-regular
+                    cursor-pointer hover:bg-gray-100 text-sm
                     flex items-center justify-start
-                    w-[75px] h-[36px] lg:w-[164px] lg:h-[64px] px-2
+                    w-20 h-9 lg:w-40 lg:h-16 px-2
                   "
                 >
                   {option.label}
@@ -93,9 +94,9 @@ export default function Dropdown({ label, options, onSelect, multiColumn }: Drop
                   key={option.value}
                   onClick={() => handleSelect(option)}
                   className="
-                    cursor-pointer hover:bg-gray-100 text-14-regular
+                    cursor-pointer hover:bg-gray-100 text-sm
                     flex items-center justify-start
-                    w-[89px] h-[36px] lg:w-[328px] lg:h-[64px] px-3
+                    w-22 h-9 lg:w-80 lg:h-16 px-3
                   "
                 >
                   {option.label}

--- a/src/app/(with-public)/mover-search/_components/FavoriteDriverList.tsx
+++ b/src/app/(with-public)/mover-search/_components/FavoriteDriverList.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import MoverProfile from '@/components/common/profile/MoverProfile';
+import MoveChip from '@/components/common/chips/MoveChip';
+
+export default function FavoriteDriverList() {
+  return (
+    <div className="mt-8 flex flex-col gap-4 rounded-lg">
+      <h2 className="text-18-semibold">찜한 기사님</h2>
+      {/* 반복 렌더링할 때 map 사용 예정 */}
+      {[1, 2].map((_, i) => (
+        <div
+          key={i}
+          className="bg-white rounded-lg border border-gray-50 p-3 flex flex-col gap-2 shadow-sm"
+        >
+          {/* 칩 섹션 */}
+          <div className="flex gap-1">
+            <MoveChip type="SMALL" mini={false} />
+            <MoveChip type="DESIGNATED" mini={false} />
+          </div>
+
+          {/* 소개글 */}
+          <p className="text-14-medium text-gray-700">
+            고객님의 물품을 안전하게 운송해 드립니다.
+          </p>
+
+          {/* 프로필 */}
+          <MoverProfile
+            forceMobileStyle={true}
+            big={false}
+            isLiked={true}
+            handleLikedClick={() => console.log('좋아요 클릭')}
+            nickName="김코드"
+            favoriteCount={136}
+            averageReviewRating={5.0}
+            reviewCount={178}
+            career={7}
+            estimateCount={334}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(with-public)/mover-search/_components/FilterAreaServiceBox.tsx
+++ b/src/app/(with-public)/mover-search/_components/FilterAreaServiceBox.tsx
@@ -7,35 +7,43 @@ interface Props {
   onSelect: (type: string, option: DropdownOption) => void;
 }
 
-export default function FilterAreaServiceBox({ areaOptions, serviceOptions, onSelect }: Props) {
+export default function FilterAreaServiceBox({
+  areaOptions,
+  serviceOptions,
+  onSelect,
+}: Props) {
   return (
     <>
-    <div className="hidden lg:block">
-      <div className="flex flex-row justify-between items-center mb-6">
-        <h2 className="text-18-semibold">필터</h2>
-        <p className="text-gray-300 cursor-pointer">초기화</p>
+      <div className="hidden lg:block">
+        <div className="flex flex-row justify-between items-center mb-6">
+          <h2 className="text-lg font-semibold">필터</h2>
+          <p className="text-gray-300 cursor-pointer">초기화</p>
+        </div>
       </div>
-    </div>
-    
-    <div className="flex flex-row lg:block w-full lg:w-[328px] mb-1">
-      <div className="mr-3 lg:mb-4">
-        <label className="hidden lg:block text-18-semibold mb-2">지역을 선택해주세요</label>
-        <Dropdown
-          label="지역"
-          options={areaOptions}
-          onSelect={(option) => onSelect("지역", option)}
-          multiColumn
-        />
+
+      <div className="flex flex-row lg:flex-col w-full lg:w-80 mb-1">
+        <div className="mr-3 lg:mb-5">
+          <label className="hidden lg:block text-lg font-semibold mb-2">
+            지역을 선택해주세요
+          </label>
+          <Dropdown
+            label="지역"
+            options={areaOptions}
+            onSelect={(option) => onSelect("지역", option)}
+            multiColumn
+          />
+        </div>
+        <div>
+          <label className="hidden lg:block text-lg font-semibold mb-2">
+            어떤 서비스가 필요하세요?
+          </label>
+          <Dropdown
+            label="서비스"
+            options={serviceOptions}
+            onSelect={(option) => onSelect("서비스", option)}
+          />
+        </div>
       </div>
-      <div className="">
-        <label className="hidden lg:block text-18-semibold mb-2">어떤 서비스가 필요하세요?</label>
-        <Dropdown
-          label="서비스"
-          options={serviceOptions}
-          onSelect={(option) => onSelect("서비스", option)}
-        />
-      </div>
-    </div>
     </>
   );
 }

--- a/src/app/(with-public)/mover-search/_components/FilterAreaServiceBox.tsx
+++ b/src/app/(with-public)/mover-search/_components/FilterAreaServiceBox.tsx
@@ -1,0 +1,41 @@
+// components/FilterAreaServiceBox.tsx
+import Dropdown, { DropdownOption } from "./Dropdown";
+
+interface Props {
+  areaOptions: DropdownOption[];
+  serviceOptions: DropdownOption[];
+  onSelect: (type: string, option: DropdownOption) => void;
+}
+
+export default function FilterAreaServiceBox({ areaOptions, serviceOptions, onSelect }: Props) {
+  return (
+    <>
+    <div className="hidden lg:block">
+      <div className="flex flex-row justify-between items-center mb-6">
+        <h2 className="text-18-semibold">필터</h2>
+        <p className="text-gray-300 cursor-pointer">초기화</p>
+      </div>
+    </div>
+    
+    <div className="flex flex-row lg:block w-full lg:w-[328px] mb-1">
+      <div className="mr-3 lg:mb-4">
+        <label className="hidden lg:block text-18-semibold mb-2">지역을 선택해주세요</label>
+        <Dropdown
+          label="지역"
+          options={areaOptions}
+          onSelect={(option) => onSelect("지역", option)}
+          multiColumn
+        />
+      </div>
+      <div className="">
+        <label className="hidden lg:block text-18-semibold mb-2">어떤 서비스가 필요하세요?</label>
+        <Dropdown
+          label="서비스"
+          options={serviceOptions}
+          onSelect={(option) => onSelect("서비스", option)}
+        />
+      </div>
+    </div>
+    </>
+  );
+}

--- a/src/app/(with-public)/mover-search/_components/SearchBar.tsx
+++ b/src/app/(with-public)/mover-search/_components/SearchBar.tsx
@@ -1,0 +1,17 @@
+import Image from 'next/image';
+import Search from '@/assets/images/searchIcon.svg'
+
+export default function SearchBar() {
+  return (
+    <div className="w-full">
+      <div className="flex items-center w-full px-4 py-3 rounded-[12px] bg-bg-200 text-gray-400">
+        <Image src={Search} alt="기사님 프로필" className="w-4 h-4 mr-2 " />
+        <input
+          type="text"
+          placeholder="텍스트를 입력해 주세요."
+          className="w-full bg-transparent text-14-regular placeholder-gray-400 focus:outline-none"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-public)/mover-search/_components/SearchBar.tsx
+++ b/src/app/(with-public)/mover-search/_components/SearchBar.tsx
@@ -1,15 +1,15 @@
 import Image from 'next/image';
-import Search from '@/assets/images/searchIcon.svg'
+import Search from '@/assets/images/searchIcon.svg';
 
 export default function SearchBar() {
   return (
     <div className="w-full">
-      <div className="flex items-center w-full px-4 py-3 rounded-[12px] bg-bg-200 text-gray-400">
-        <Image src={Search} alt="기사님 프로필" className="w-4 h-4 mr-2 " />
+      <div className="flex items-center w-full px-4 py-3 rounded-xl bg-bg-200 text-gray-400">
+        <Image src={Search} alt="기사님 프로필" className="w-4 h-4 mr-2" />
         <input
           type="text"
           placeholder="텍스트를 입력해 주세요."
-          className="w-full bg-transparent text-14-regular placeholder-gray-400 focus:outline-none"
+          className="w-full bg-transparent text-sm placeholder-gray-400 focus:outline-none"
         />
       </div>
     </div>

--- a/src/app/(with-public)/mover-search/_components/SortDropdown.tsx
+++ b/src/app/(with-public)/mover-search/_components/SortDropdown.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useState, useRef } from "react";
-import chevronDownIcon from "@/assets/images/chevronDownIcon.svg"
+import chevronDownIcon from "@/assets/images/chevronDownIcon.svg";
 
 interface DropdownOption {
   label: string;
@@ -28,35 +28,33 @@ export default function SortDropdown() {
   };
 
   // 외부 클릭 시 닫기
-    useEffect(() => {
-      const handleClickOutside = (event: MouseEvent) => {
-        if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-          setIsOpen(false);
-        }
-      };
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }, []);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   return (
     <div ref={dropdownRef} className="relative inline-block text-left">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-[91px] h-[32px] lg:w-[114px] lg:h-[40px] rounded-lg text-12-regular lg:text-14-regular flex items-center justify-center"
+        className="w-24 h-8 lg:w-28 lg:h-10 rounded-lg text-xs lg:text-sm flex items-center justify-center gap-1"
       >
         {selected.label}
-        <Image src={chevronDownIcon} alt="dropdownIcon" className="w-[20px] h-[20px]" />
+        <Image src={chevronDownIcon} alt="dropdownIcon" className="w-5 h-5" />
       </button>
 
       {isOpen && (
-        <div
-          className="absolute right-0 mt-2 w-[91px]  lg:w-[114px] bg-white border border-gray-100 rounded-lg shadow-md z-10"
-        >
+        <div className="absolute right-0 mt-2 w-24 lg:w-28 bg-white border border-gray-100 rounded-lg shadow-md z-10">
           {sortOptions.map((option) => (
             <div
               key={option.value}
               onClick={() => handleSelect(option)}
-              className="w-full h-[32px] lg:w-[114px] lg:h-[40px] px-3 flex items-center cursor-pointer hover:bg-gray-100 text-14-regular"
+              className="w-full h-8 lg:h-10 px-3 flex items-center cursor-pointer hover:bg-gray-100 text-sm"
             >
               {option.label}
             </div>

--- a/src/app/(with-public)/mover-search/_components/SortDropdown.tsx
+++ b/src/app/(with-public)/mover-search/_components/SortDropdown.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState, useRef } from "react";
+import chevronDownIcon from "@/assets/images/chevronDownIcon.svg"
+
+interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+const sortOptions: DropdownOption[] = [
+  { label: "리뷰 많은순", value: "mostReviewed" },
+  { label: "평점 높은순", value: "highRating" },
+  { label: "경력 높은순", value: "highExperience" },
+  { label: "확정 많은순", value: "mostBooked" },
+];
+
+export default function SortDropdown() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<DropdownOption>(sortOptions[0]);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleSelect = (option: DropdownOption) => {
+    setSelected(option);
+    setIsOpen(false);
+    console.log("정렬 선택됨:", option);
+  };
+
+  // 외부 클릭 시 닫기
+    useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+          setIsOpen(false);
+        }
+      };
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
+
+  return (
+    <div ref={dropdownRef} className="relative inline-block text-left">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-[91px] h-[32px] lg:w-[114px] lg:h-[40px] rounded-lg text-12-regular lg:text-14-regular flex items-center justify-center"
+      >
+        {selected.label}
+        <Image src={chevronDownIcon} alt="dropdownIcon" className="w-[20px] h-[20px]" />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 mt-2 w-[91px]  lg:w-[114px] bg-white border border-gray-100 rounded-lg shadow-md z-10"
+        >
+          {sortOptions.map((option) => (
+            <div
+              key={option.value}
+              onClick={() => handleSelect(option)}
+              className="w-full h-[32px] lg:w-[114px] lg:h-[40px] px-3 flex items-center cursor-pointer hover:bg-gray-100 text-14-regular"
+            >
+              {option.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(with-public)/mover-search/page.tsx
+++ b/src/app/(with-public)/mover-search/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import PageTitle from "@/components/layout/PageTitle";
 import DriverList from './_components/DriverList';
 import SortDropdown from './_components/SortDropdown';
@@ -7,80 +8,54 @@ import SearchBar from './_components/SearchBar';
 import { DropdownOption } from './_components/Dropdown';
 import FavoriteDriverList from "./_components/FavoriteDriverList";
 
-const areaOptions: DropdownOption[] = [
-  { label: "전체", value: "all" },
-  { label: "서울", value: "seoul" },
-  { label: "인천", value: "incheon" },
-  { label: "대전", value: "daejeon" },
-  { label: "대구", value: "daegu" },
-  { label: "광주", value: "gwangju" },
-  { label: "부산", value: "busan" },
-  { label: "울산", value: "ulsan" },
-  { label: "세종", value: "sejong" },
-  { label: "경기", value: "gyeonggi" },
-  { label: "강원", value: "gangwon" },
-  { label: "충북", value: "chungbuk" },
-  { label: "충남", value: "chungnam" },
-  { label: "전북", value: "jeonbuk" },
-  { label: "전남", value: "jeonnam" },
-  { label: "경북", value: "gyeongbuk" },
-  { label: "경남", value: "gyeongnam" },
-  { label: "제주", value: "jeju" },
-];
+const areaOptions: DropdownOption[] = [/* 생략 */];
+const serviceOptions: DropdownOption[] = [/* 생략 */];
 
-const serviceOptions: DropdownOption[] = [
-  { label: "전체", value: "all" },
-  { label: "소형이사", value: "SMALL" },
-  { label: "가정이사", value: "HOME" },
-  { label: "사무실이사", value: "OFFICE" },
-];
-
-//기사님 찾기
 export default function FindDriverPage() {
-    const handleSelect = (type: string, option: DropdownOption) => {
-        console.log(`${type} selected:`, option);
-      };
-    return(
-        <div>
-            <PageTitle title="기사님 찾기"/>
-            <div className="min-h-screen pt-6 pb-10 min-w-[375px] md:max-w-[744px] lg:max-w-[1400px] mx-auto">
+  const handleSelect = (type: string, option: DropdownOption) => {
+    console.log(`${type} selected:`, option);
+  };
 
-              <div className="flex flex-col lg:flex-row lg:gap-[120px]">      
+  return (
+    <div>
+      <PageTitle title="기사님 찾기" />
+      <div className="min-h-screen pt-6 pb-10 min-w-full md:max-w-3xl lg:max-w-6xl mx-auto">
+        <div className="flex flex-col items-center lg:flex-row lg:gap-32">
+          {/* PC 사이즈 - 왼쪽 사이드바 */}
+          <div className="hidden lg:block w-80 shrink-0">
+            <FilterAreaServiceBox
+              areaOptions={areaOptions}
+              serviceOptions={serviceOptions}
+              onSelect={handleSelect}
+            />
+            <FavoriteDriverList />
+          </div>
 
-                {/* PC 사이즈 - 왼쪽 사이드바 */}
-                <div className="hidden lg:block w-[328px] shrink-0">
-                  <FilterAreaServiceBox
-                    areaOptions={areaOptions}
-                    serviceOptions={serviceOptions}
-                    onSelect={handleSelect}
-                  />
-                  <FavoriteDriverList />
-                </div>
+          {/* Content Section */}
+          <div className="flex-1 w-80 md:w-[36rem] lg:w-full box-border">
+            <div className="w-full flex flex-row justify-between">
+              {/* 모바일 & 중간 사이즈 - 필터 상단에 노출 */}
+              <div className="block lg:hidden mb-6">
+                <FilterAreaServiceBox
+                  areaOptions={areaOptions}
+                  serviceOptions={serviceOptions}
+                  onSelect={handleSelect}
+                />
+              </div>
 
-                {/* Content Section */}
-                <div className="flex-1 w-[327px] md:w-[600px] lg:w-[955px] box-border">
-                  <div className="w-full flex flex-row justify-between">
-                    
-                      {/* 모바일 & 중간 사이즈 - 필터 상단에 노출 */}
-                      <div className="block lg:hidden  mb-6">
-                          <FilterAreaServiceBox
-                          areaOptions={areaOptions}
-                          serviceOptions={serviceOptions}
-                          onSelect={handleSelect}
-                          />
-                      </div>
-
-                      <div className="ml-auto">
-                        <SortDropdown />
-                      </div>
-                  </div>
-                  <div className="relative mb-6">
-                    <SearchBar />
-                  </div>
-                  <DriverList />
-                </div>
+              <div className="ml-auto">
+                <SortDropdown />
               </div>
             </div>
+
+            <div className="relative mb-6">
+              <SearchBar />
+            </div>
+
+            <DriverList />
+          </div>
         </div>
-    )
+      </div>
+    </div>
+  );
 }

--- a/src/app/(with-public)/mover-search/page.tsx
+++ b/src/app/(with-public)/mover-search/page.tsx
@@ -1,11 +1,86 @@
+'use client';
 import PageTitle from "@/components/layout/PageTitle";
+import DriverList from './_components/DriverList';
+import SortDropdown from './_components/SortDropdown';
+import FilterAreaServiceBox from './_components/FilterAreaServiceBox';
+import SearchBar from './_components/SearchBar';
+import { DropdownOption } from './_components/Dropdown';
+import FavoriteDriverList from "./_components/FavoriteDriverList";
+
+const areaOptions: DropdownOption[] = [
+  { label: "전체", value: "all" },
+  { label: "서울", value: "seoul" },
+  { label: "인천", value: "incheon" },
+  { label: "대전", value: "daejeon" },
+  { label: "대구", value: "daegu" },
+  { label: "광주", value: "gwangju" },
+  { label: "부산", value: "busan" },
+  { label: "울산", value: "ulsan" },
+  { label: "세종", value: "sejong" },
+  { label: "경기", value: "gyeonggi" },
+  { label: "강원", value: "gangwon" },
+  { label: "충북", value: "chungbuk" },
+  { label: "충남", value: "chungnam" },
+  { label: "전북", value: "jeonbuk" },
+  { label: "전남", value: "jeonnam" },
+  { label: "경북", value: "gyeongbuk" },
+  { label: "경남", value: "gyeongnam" },
+  { label: "제주", value: "jeju" },
+];
+
+const serviceOptions: DropdownOption[] = [
+  { label: "전체", value: "all" },
+  { label: "소형이사", value: "SMALL" },
+  { label: "가정이사", value: "HOME" },
+  { label: "사무실이사", value: "OFFICE" },
+];
 
 //기사님 찾기
-export default function Page() {
+export default function FindDriverPage() {
+    const handleSelect = (type: string, option: DropdownOption) => {
+        console.log(`${type} selected:`, option);
+      };
     return(
         <div>
             <PageTitle title="기사님 찾기"/>
-            컨텐츠
+            <div className="min-h-screen pt-6 pb-10 min-w-[375px] md:max-w-[744px] lg:max-w-[1400px] mx-auto">
+
+              <div className="flex flex-col lg:flex-row lg:gap-[120px]">      
+
+                {/* PC 사이즈 - 왼쪽 사이드바 */}
+                <div className="hidden lg:block w-[328px] shrink-0">
+                  <FilterAreaServiceBox
+                    areaOptions={areaOptions}
+                    serviceOptions={serviceOptions}
+                    onSelect={handleSelect}
+                  />
+                  <FavoriteDriverList />
+                </div>
+
+                {/* Content Section */}
+                <div className="flex-1 w-[327px] md:w-[600px] lg:w-[955px] box-border">
+                  <div className="w-full flex flex-row justify-between">
+                    
+                      {/* 모바일 & 중간 사이즈 - 필터 상단에 노출 */}
+                      <div className="block lg:hidden  mb-6">
+                          <FilterAreaServiceBox
+                          areaOptions={areaOptions}
+                          serviceOptions={serviceOptions}
+                          onSelect={handleSelect}
+                          />
+                      </div>
+
+                      <div className="ml-auto">
+                        <SortDropdown />
+                      </div>
+                  </div>
+                  <div className="relative mb-6">
+                    <SearchBar />
+                  </div>
+                  <DriverList />
+                </div>
+              </div>
+            </div>
         </div>
     )
 }

--- a/src/components/common/chips/MoveChip.tsx
+++ b/src/components/common/chips/MoveChip.tsx
@@ -8,7 +8,7 @@ type ChipType = "SMALL" | "HOME" | "OFFICE" | "DESIGNATED" | "PENDING";
 
 const CHIP_CONFIG: Record<
   ChipType,
-  { label: string; bg: string; text: string; icon?: StaticImageData }
+  { label: string; bg: string; text: string; icon?: string | StaticImageData }
 > = {
   SMALL: {
     label: "소형이사",

--- a/src/components/common/profile/MoverProfile.tsx
+++ b/src/components/common/profile/MoverProfile.tsx
@@ -11,6 +11,7 @@ type MoverProfileProps = {
   profileImage?: string;
   big?: boolean;
   isLiked?: boolean;
+  forceMobileStyle?: boolean;
   handleLikedClick: () => void;
   nickName: string;
   favoriteCount: number;
@@ -24,6 +25,7 @@ export default function MoverProfile({
   profileImage, // 기사님 이미지
   big, // 찜한 기사님 페이지 사용
   isLiked, // 찜 여부확인용
+  forceMobileStyle = false, // lg일 때도 모바일 사이즈 강제 적용
   handleLikedClick, // 찜 하기, 취소하기
   nickName,
   favoriteCount,
@@ -32,20 +34,30 @@ export default function MoverProfile({
   career,
   estimateCount, // 스키마 필드명 그대로 사용했습니다
 }: MoverProfileProps) {
+  const isBig = big && !forceMobileStyle;
+
+  const containerClass = [
+    "flex items-center bg-white rounded-md border border-line-100 w-full h-19.5 shadow-[4px_4px_16px_0px_rgba(233,233,233,0.10)]",
+    forceMobileStyle
+      ? "lg:h-19.5 px-2.5 py-4"
+      : isBig
+      ? "lg:h-28 px-4.5 py-4"
+      : "lg:h-23 px-2.5 py-4",
+  ].join(" ");
+
+  const profileImageClass = [
+    "relative rounded-full overflow-hidden mr-3",
+    forceMobileStyle
+      ? "w-11.5 h-11.5"
+      : isBig
+      ? "lg:w-20 lg:h-20 w-14 h-14 mr-6"
+      : "lg:w-14 lg:h-14 w-11.5 h-11.5 mr-3",
+  ].join(" ");
+
   return (
-    <div
-      className={
-        `flex items-center bg-white rounded-md border border-line-100 px-2.5 py-4 lg:px-4.5 lg:py-4 w-full h-19.5 shadow-[4px_4px_16px_0px_rgba(233,233,233,0.10)] ` +
-        (big ? "lg:h-28" : "lg:h-23")
-      }
-    >
+    <div className={containerClass}>
       {/* 프로필 이미지 */}
-      <div
-        className={
-          "relative rounded-full overflow-hidden mr-3 lg:mr-6 w-11.5 h-11.5 " +
-          (big ? "lg:w-20 lg:h-20" : "lg:w-14 lg:h-14")
-        }
-      >
+      <div className={profileImageClass}>
         <Image
           src={profileImage || profile}
           alt="프로필"
@@ -56,7 +68,13 @@ export default function MoverProfile({
       {/* 정보 영역 */}
       <div className="flex-1">
         <div className="flex items-center justify-between">
-          <span className="text-14-semibold lg:text-18-semibold text-black-300">
+          <span
+            className={
+              forceMobileStyle
+                ? "text-14-semibold text-black-300"
+                : "text-14-semibold lg:text-18-semibold text-black-300"
+            }
+          >
             {nickName} 기사님
           </span>
           <div className="flex items-center">
@@ -66,28 +84,52 @@ export default function MoverProfile({
                 width={24}
                 height={24}
                 alt="좋아요"
-                className="mr-0.5 lg:mr-1"
+                className={forceMobileStyle ? "mr-0.5" : "mr-0.5 lg:mr-1"}
               />
             </button>
-            <span className="text-13-medium lg:text-18-medium text-black-300">
+            <span
+              className={
+                forceMobileStyle
+                  ? "text-13-medium text-black-300"
+                  : "text-13-medium lg:text-18-medium text-black-300"
+              }
+            >
               {favoriteCount}
             </span>
           </div>
         </div>
-        <div className="flex items-center mt-3 lg:mt-4 text-13-medium lg:text-16-medium text-gray-300">
-          <span className="flex items-center gap-0.5 lg:gap-1">
+        <div
+          className={
+            forceMobileStyle
+              ? "flex items-center mt-3 text-13-medium text-gray-300"
+              : "flex items-center mt-3 lg:mt-4 text-13-medium lg:text-16-medium text-gray-300"
+          }
+        >
+          <span className="flex items-center gap-0.5">
             <Image src={star} width={16} height={16} alt="별점" />
-            <span className=" text-black-300">{averageReviewRating}</span>
+            <span className="text-black-300">{averageReviewRating}</span>
             <span>({reviewCount})</span>
           </span>
-          <span className="h-3 w-px bg-line-200 mx-2.5 lg:mx-4"></span>
-          <span className="flex items-center gap-0.5 lg:gap-1">
+          <span
+            className={
+              forceMobileStyle
+                ? "h-3 w-px bg-line-200 mx-2.5"
+                : "h-3 w-px bg-line-200 mx-2.5 lg:mx-4"
+            }
+          ></span>
+          <span className="flex items-center gap-0.5">
             <span>경력</span>
-            <span className=" text-black-300 ">{career}년</span>
+            <span className="text-black-300">{career}년</span>
           </span>
-          <span className="h-3 w-px bg-line-200 mx-2.5 lg:mx-4 "></span>
-          <span className="flex items-center gap-0.5 lg:gap-1">
-            <span className=" text-black-300">{estimateCount}건</span>
+          <span
+            className={
+              forceMobileStyle
+                ? "h-3 w-px bg-line-200 mx-2.5"
+                : "h-3 w-px bg-line-200 mx-2.5 lg:mx-4"
+            }
+          ></span>
+          <span className="flex items-center gap-0.5">
+            <span className="text-black-300">{estimateCount}건</span>
             <span>확정</span>
           </span>
         </div>

--- a/src/lib/types/svg.d.ts
+++ b/src/lib/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## 작업 개요
- 기사님 찾기 페이지 요구사항 반영
- MoverProfile, MoverChip 요구사항 반영 및 에러에 의해 수정

---

## 작업 상세 내용
- [x] 직접적인 수치 -> tailwind 문법으로 변경 완
- [x] 찜 기능 추가 -> lg상태일 때도 기사 프로필이 모바일 사이즈로 나오도록 기능 추가
- [x] 모바일과 PC 버전 사이 디테일 수정

---

## 🗂️ 수정한 파일
- `src/app/(with-public)/mover-search` 내부 파일
- `src/components/common/profile/MoverProfile.tsx` 
- `src/components/common/chips/MoverChip.tsx`
---

## 🗂️ 새로 작성한 파일
- - `src/lib/types/svg.d.ts`

---

## 기타 참고 사항
- 로그인/비로그인에 따른 찜 리스트 > 로그인 기능 어느정도 완성 후 적용할 예정
- MoverProfile: 기사 찾기 페이지의 경우 찜 리스트에서는 lg사이즈임에도 모바일처럼 작동해야하기 때문에 forceMobileStyle을 넣어서 수정
- MoverChip: svg 타입에러로 수정

