### PR TITLE
fix: 배포 사이트에서 로그인/회원가입 오류 수정

### DIFF
--- a/src/lib/actions/auth/create-client-local-login.action.ts
+++ b/src/lib/actions/auth/create-client-local-login.action.ts
@@ -36,8 +36,6 @@ export default async function createClientLocalLoginAction(
       const response = await defaultFetch("/auth/signin/client", {
          method: "POST",
          body: JSON.stringify(validationResult.data),
-         credentials: "include",
-         cache: "no-store",
       });
 
       // 성공 응답
@@ -49,14 +47,15 @@ export default async function createClientLocalLoginAction(
    } catch (error: unknown) {
       console.error("로그인 실패 원인: ", error);
 
+      // 문자열 message, 객체 data 중 message 받음
       if (isFetchError(error)) {
-         const message = error.body.message;
+         const { message } = error.body;
 
-         if (message.includes("사용자를 찾을 수 없습니다")) {
+         if (message.includes("사용자")) {
             return { success: false, fieldErrors: { email: message } };
          }
 
-         if (message.includes("비밀번호를 잘못 입력하셨습니다.")) {
+         if (message.includes("비밀번호")) {
             return { success: false, fieldErrors: { password: message } };
          }
       }

--- a/src/lib/actions/auth/create-client-local-signup.action.ts
+++ b/src/lib/actions/auth/create-client-local-signup.action.ts
@@ -48,17 +48,13 @@ export default async function createClientLocalSignupAction(
 
       // ✅ BE 오류 받음 (이메일, 전화번호 중복)
       if (isFetchError(error)) {
-         const message = error.body.message;
+         const { data } = error.body;
 
-         // message에 JSON 형태 오류가 들어오면 Parsing
-         const parsedErrors = JSON.parse(
-            message.replace("회원가입 실패: ", ""),
-         );
-
-         if (typeof parsedErrors === "object" && parsedErrors !== null) {
+         // 객체 형태라 data 형태로 오류 반환 (문자면 위에서 message를 받음)
+         if (data && typeof data === "object") {
             return {
                success: false,
-               fieldErrors: parsedErrors,
+               fieldErrors: data as Record<string, string>,
             };
          }
       }

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -42,7 +42,14 @@ export async function defaultFetch(
 
    // ★ 응답
    try {
-      const response = await fetch(url, { ...options, headers, body });
+      const response = await fetch(url, {
+         ...options,
+         headers,
+         body,
+         cache: "no-store",
+         credentials: "include",
+         next: { revalidate: 0 },
+      });
       if (!response.ok) {
          const errorBody = await response.json();
          throw { status: response.status, body: errorBody };
@@ -100,8 +107,10 @@ export async function tokenFetch(
    let response = await fetch(url, {
       ...options,
       headers,
-      credentials: "include",
       body,
+      credentials: "include",
+      cache: "no-store",
+      next: { revalidate: 0 },
    });
 
    // 401 오류면 토큰 재발급 시도

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "https://www.moving-web.site"; // "http://localhost:4000";
+export const BASE_URL = "https://sixth-moving-4team-be.onrender.com"; // "http://localhost:4000";
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "https://sixth-moving-4team-be.onrender.com"; // "http://localhost:4000";
+export const BASE_URL = "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "https://fe13364ba3c7.ngrok-free.app/"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
+export const BASE_URL = "https://7345e07e08fa.ngrok-free.app"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,22 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "https://7345e07e08fa.ngrok-free.app"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
+export const BASE_URL = process.env.BACKEND_URL || "http://localhost:4000";
+
+// ✅ 서버에서 던진 오류 받기: 문자 형태, 객체 형태(data로 받음)
+async function handleResponse(response: Response) {
+   if (!response.ok) {
+      const errorBody = await response.json();
+      throw {
+         status: response.status,
+         body: {
+            message: errorBody.message || "서버 오류 발생",
+            data: errorBody.data || undefined,
+         },
+      };
+   }
+   return response.json();
+}
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(
@@ -50,12 +65,8 @@ export async function defaultFetch(
          credentials: "include",
          next: { revalidate: 0 },
       });
-      if (!response.ok) {
-         const errorBody = await response.json();
-         throw { status: response.status, body: errorBody };
-      }
 
-      return response.json();
+      return await handleResponse(response);
    } catch (error: unknown) {
       console.error("defaultFetch Error: ", error);
 
@@ -104,45 +115,38 @@ export async function tokenFetch(
    }
 
    // ★ 요청
-   let response = await fetch(url, {
-      ...options,
-      headers,
-      body,
-      credentials: "include",
-      cache: "no-store",
-      next: { revalidate: 0 },
-   });
-
-   // 401 오류면 토큰 재발급 시도
-   if (response.status === 401) {
-      try {
-         accessToken = await accessTokenSettings.refresh();
-         headers.Authorization = `Bearer ${accessToken}`;
-
-         response = await fetch(url, {
-            ...options,
-            headers,
-            credentials: "include",
-            body,
-         });
-      } catch (error) {
-         console.error("토큰 갱신 실패:", error);
-         accessTokenSettings.clear();
-         onAuthFail?.();
-         throw new Error("토큰 갱신에 실패했습니다. 재로그인을 시도해 주세요.");
-      }
-   }
-
-   if (response.status === 204) return null;
-
-   // !response.ok + 반환
    try {
-      if (!response.ok) {
-         const errorBody = await response.json();
-         throw { status: response.status, body: errorBody };
+      let response = await fetch(url, {
+         ...options,
+         headers,
+         body,
+         credentials: "include",
+         cache: "no-store",
+         next: { revalidate: 0 },
+      });
+
+      // 401 오류면 토큰 재발급 시도
+      if (response.status === 401) {
+         try {
+            accessToken = await accessTokenSettings.refresh();
+            headers.Authorization = `Bearer ${accessToken}`;
+
+            response = await fetch(url, {
+               ...options,
+               headers,
+               body,
+            });
+         } catch (error) {
+            console.error("토큰 갱신 실패:", error);
+            accessTokenSettings.clear();
+            onAuthFail?.();
+            throw new Error(
+               "토큰 갱신에 실패했습니다. 재로그인을 시도해 주세요.",
+            );
+         }
       }
 
-      return response.json();
+      return await handleResponse(response);
    } catch (error: unknown) {
       console.error("token Fetch Error: ", error);
 

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "https://e06065a2214e.ngrok-free.app"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
+export const BASE_URL = "https://383e9760a457.ngrok-free.app"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
+export const BASE_URL = "https://e06065a2214e.ngrok-free.app"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = "https://383e9760a457.ngrok-free.app"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
+export const BASE_URL = "https://fe13364ba3c7.ngrok-free.app/"; // "http://localhost:4000"; // "https://sixth-moving-4team-be.onrender.com";
 
 // ✅ with-guest, with-public 경로에서 쓰는 미로그인 전용 fetch
 export async function defaultFetch(

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -9,8 +9,9 @@
 import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
-// ✅ 기본 url : 두 개를 바꿔 가면서 쓰세요.
-export const BASE_URL = process.env.BACKEND_URL || "http://localhost:4000";
+// ✅ 기본 url : 환경 변수 설정해서 쓰세요.
+export const BASE_URL =
+   process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 // ✅ 서버에서 던진 오류 받기: 문자 형태, 객체 형태(data로 받음)
 async function handleResponse(response: Response) {


### PR DESCRIPTION
## 작업 개요
- 배포 사이트에서 로그인/회원가입 오류 수정

---

## 작업 상세 내용
회원가입/로그인 시 데이터가 안 넘어가지는 오류가 있었다. 확인 결과, Server action + Vercel을 쓰면 백엔드 api가 아니라 요청 보낸 그 api(ex. api.moving-web.site/sign-up/client)로 요청이 들어간다. 그래서 클라이언트 fetch API가 아니라 Node.js runtime fetch를 써야 한다.

- [x] 그 코드가 next: { revalidate: 0 } 이다. 넣었다.
- [x] 백엔드에서 error 받는 형태를 JSON으로 안 감싸고 errorHandler를 이용해 객체 형태로 받았다.
- [x] 그에 맞춰 코드 수정
- [x] fetch-client 조금 refactoring

---

## 🗂️ 수정한 파일
- `src/lib/actions/auth/create-client-local-login.action.ts`
- `src/lib/actions/auth/create-client-local-signup.action.ts`
- `src/lib/api/fetch-client.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- 각자 .env 파일 만들어서 쓰시면 될 것 같습니다.