### PR TITLE
feat: 기사님 로그인, 회원가입 fetch

### DIFF
--- a/src/components/sign-up-in/MoverLoginForm.tsx
+++ b/src/components/sign-up-in/MoverLoginForm.tsx
@@ -52,9 +52,6 @@ export default function MoverLoginForm() {
       }
    }, [formState, login, router]);
 
-   //디버깅
-   console.log("formState.fieldErrors", formState?.fieldErrors);
-
    return (
       <form action={moverFormAction} className="flex w-full flex-col gap-4">
          <AuthInput

--- a/src/components/sign-up-in/MoverLoginForm.tsx
+++ b/src/components/sign-up-in/MoverLoginForm.tsx
@@ -15,7 +15,7 @@ export default function MoverLoginForm() {
    const router = useRouter();
    const { login } = useAuth();
 
-   const [state, moverFormAction, isPending] = useActionState(
+   const [formState, moverFormAction, isPending] = useActionState(
       createMoverLocalLoginAction,
       null,
    );
@@ -31,20 +31,29 @@ export default function MoverLoginForm() {
       setValidity((prev) => ({ ...prev, [key]: isValid }));
    };
 
+   //입력 값 변경 시 서버 오류 제거
+   const handleValueChange = (key: string) => {
+      if (formState?.fieldErrors && typeof formState.fieldErrors === "object") {
+         const newErrors = { ...formState.fieldErrors };
+         delete newErrors[key];
+         formState.fieldErrors = newErrors;
+      }
+   };
+
    //버튼 활성화 조건
    const isDisabled =
       isPending || !Object.values(validity).every((v) => v === true);
 
    //로그인 성공 시 프로필 생성 페이지로 리다이렉트
    useEffect(() => {
-      if (state?.success) {
-         const { user, accessToken } = state;
-         if (user && accessToken) {
-            login(user, accessToken);
-            router.push("/profile/create");
-         }
+      if (formState?.success && formState.user && formState?.accessToken) {
+         login(formState.user, formState.accessToken);
+         router.push("/profile/create");
       }
-   }, [state, login, router]);
+   }, [formState, login, router]);
+
+   //디버깅
+   console.log("formState.fieldErrors", formState?.fieldErrors);
 
    return (
       <form action={moverFormAction} className="flex w-full flex-col gap-4">
@@ -55,6 +64,8 @@ export default function MoverLoginForm() {
             type="email"
             placeholder="이메일을 입력해 주세요"
             onValidChange={handleValidateChange}
+            onValueChange={handleValueChange}
+            serverError={formState?.fieldErrors?.email}
          />
          <PasswordInput
             name="password"
@@ -63,6 +74,8 @@ export default function MoverLoginForm() {
             type="password"
             placeholder="비밀번호를 입력해 주세요"
             onValidChange={handleValidateChange}
+            onValueChange={handleValueChange}
+            serverError={formState?.fieldErrors?.password}
          />
 
          {/* 로그인 버튼 */}

--- a/src/components/sign-up-in/MoverSignUpForm.tsx
+++ b/src/components/sign-up-in/MoverSignUpForm.tsx
@@ -7,49 +7,80 @@ import SolidButton from "../common/buttons/SolidButton";
 import Link from "next/link";
 
 import {
-   validateAuthCheckPassword,
    validateAuthEmail,
    validateAuthName,
    validateAuthPassword,
    validateAuthPhone,
 } from "@/lib/validations";
-import createMoverLocalSignupAction from "@/lib/actions/auth/create-mover-local-signup.action";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
+import { AuthValidationResult } from "@/lib/types";
+import createMoverLocalSignupAction from "@/lib/actions/auth/create-mover-local-signup.action";
 
 export default function MoverSignUpForm() {
    const router = useRouter();
    const { login } = useAuth();
 
-   const [state, MoverFormAction, isPending] = useActionState(
+   const [formState, MoverFormAction, isPending] = useActionState(
       createMoverLocalSignupAction,
       null,
    );
 
-   //비밀번호 대조 위한 상태 관리
-   const [checkPassword, setCheckPassword] = useState("");
+   // 입력 값 상태 관리
+   const [formValues, setFormValues] = useState({
+      name: "",
+      email: "",
+      phone: "",
+      password: "",
+      passwordConfirmation: "",
+   });
 
-   const handleCheckPasswordChange = (
-      e: React.ChangeEvent<HTMLInputElement>,
-   ) => {
-      setCheckPassword(e.target.value);
-   };
+   // //비밀번호 대조 위한 상태 관리
+   // const [checkPassword, setCheckPassword] = useState("");
+
+   // const handleCheckPasswordChange = (
+   //    e: React.ChangeEvent<HTMLInputElement>,
+   // ) => {
+   //    setCheckPassword(e.target.value);
+   // };
 
    //시작하기 버튼 활성화 확인
    const [validity, setValidity] = useState<Record<string, boolean>>({
       name: false,
       email: false,
-      phoneNumber: false,
+      phone: false,
       password: false,
       passwordConfirmation: false,
    });
 
    //시작하기 버튼 활성화를 위해 InputField 컴포넌트로 내려줄 함수
-   const handleValidatyChange = (key: string, isValid: boolean) => {
+   const handleValidityChange = (key: string, isValid: boolean) => {
       setValidity((prev) => ({
          ...prev,
          [key]: isValid,
       }));
+   };
+
+   const handleValueChange = (key: string, value: string) => {
+      setFormValues((prev) => ({ ...prev, [key]: value }));
+
+      // 오류 값 초기화
+      if (formState?.fieldErrors && typeof formState.fieldErrors === "object") {
+         const newErrors = { ...formState.fieldErrors };
+         delete newErrors[key];
+         formState.fieldErrors = newErrors;
+      }
+   };
+
+   //비밀번호 확인 검증
+   const validatePasswordConfirmation = (
+      confirmPassword: string,
+   ): AuthValidationResult => {
+      if (formValues.password !== confirmPassword) {
+         return { success: false, message: "비밀번호가 일치하지 않습니다." };
+      }
+
+      return { success: true, message: "" };
    };
 
    const isDisabled =
@@ -57,14 +88,11 @@ export default function MoverSignUpForm() {
 
    //회원가입 성공 시 리다이렉트
    useEffect(() => {
-      if (state?.success && state.accessToken && state.user) {
-         login(state.user, state.accessToken);
+      if (formState?.success && formState.accessToken && formState.user) {
+         login(formState.user, formState.accessToken);
          router.push("/profile/create");
       }
-   }, [state, login, router]);
-
-   //디버깅
-   console.log("state", state);
+   }, [formState, login, router]);
 
    return (
       <form action={MoverFormAction} className="flex w-full flex-col gap-4">
@@ -74,7 +102,8 @@ export default function MoverSignUpForm() {
             validator={validateAuthName}
             type="text"
             placeholder="성함을 입력해 주세요"
-            onValidChange={handleValidatyChange}
+            onValidChange={handleValidityChange}
+            onValueChange={handleValueChange}
          />
          <AuthInput
             name="email"
@@ -82,15 +111,19 @@ export default function MoverSignUpForm() {
             validator={validateAuthEmail}
             type="email"
             placeholder="이메일을 입력해 주세요"
-            onValidChange={handleValidatyChange}
+            onValidChange={handleValidityChange}
+            onValueChange={handleValueChange}
+            serverError={formState?.fieldErrors?.email}
          />
          <AuthInput
-            name="phoneNumber"
+            name="phone"
             label="전화번호"
             validator={validateAuthPhone}
             type="text"
             placeholder="숫자만 입력해 주세요"
-            onValidChange={handleValidatyChange}
+            onValidChange={handleValidityChange}
+            onValueChange={handleValueChange}
+            serverError={formState?.fieldErrors?.phone}
          />
          <PasswordInput
             name="password"
@@ -98,16 +131,18 @@ export default function MoverSignUpForm() {
             label="비밀번호"
             type="password"
             placeholder="비밀번호를 입력해 주세요"
-            onValidChange={handleValidatyChange}
-            onChange={handleCheckPasswordChange}
+            onValidChange={handleValidityChange}
+            // onChange={handleCheckPasswordChange}
+            onValueChange={handleValueChange}
          />
          <PasswordInput
             name="passwordConfirmation"
-            validator={(val) => validateAuthCheckPassword(val, checkPassword)}
+            validator={validatePasswordConfirmation}
             label="비밀번호 확인"
             type="password"
             placeholder="비밀번호를 다시 한번 입력해 주세요"
-            onValidChange={handleValidatyChange}
+            onValidChange={handleValidityChange}
+            onValueChange={handleValueChange}
          />
 
          {/* 회원가입 버튼 */}

--- a/src/lib/actions/auth/create-mover-local-login.action.ts
+++ b/src/lib/actions/auth/create-mover-local-login.action.ts
@@ -43,42 +43,6 @@ export default async function createMoverLocalLoginAction(
          user: response.mover.user,
          accessToken: response.mover.accessToken,
       };
-
-      // // fetch 직접 요청
-      // const response = await fetch(
-      //    `${process.env.NEXT_PUBLIC_API_URL}/auth/signin/mover`,
-      //    {
-      //       method: "POST",
-      //       headers: {
-      //          "Content-Type": "application/json",
-      //       },
-      //       body: JSON.stringify(validationResult.data),
-      //       credentials: "include",
-      //       cache: "no-store",
-      //    },
-      // );
-
-      // if (!response.ok) {
-      //    throw { status: response.status };
-      // }
-
-      // const result = await response.json();
-      // console.log("서버액션 결과", result);
-
-      // // accessToken 쿠키에 저장 (서버 측 쿠키)
-      // cookies().set("accessToken", accessToken, {
-      //    httpOnly: true,
-      //    secure: process.env.NODE_ENV === "production",
-      //    path: "/",
-      //    maxAge: 60 * 60 * 1, // 1시간
-      // });
-
-      // // 성공 응답
-      // return {
-      //    success: true,
-      //    user: result.user,
-      //    accessToken: result.accessToken,
-      // };
    } catch (error) {
       console.error("로그인 실패 원인: ", error);
 

--- a/src/lib/actions/auth/create-mover-local-login.action.ts
+++ b/src/lib/actions/auth/create-mover-local-login.action.ts
@@ -40,8 +40,8 @@ export default async function createMoverLocalLoginAction(
       // 성공 응답
       return {
          success: true,
-         user: response.mover.user,
-         accessToken: response.mover.accessToken,
+         user: response.data.user,
+         accessToken: response.data.accessToken,
       };
    } catch (error) {
       console.error("로그인 실패 원인: ", error);

--- a/src/lib/actions/auth/create-mover-local-signup.action.ts
+++ b/src/lib/actions/auth/create-mover-local-signup.action.ts
@@ -35,20 +35,16 @@ export default async function createMoverLocalSignupAction(
          };
       }
 
-      //디버깅
-      console.log("validationResult.data", validationResult.data);
-
       // 백엔드 연동
       const response = await defaultFetch("/auth/signup/mover", {
          method: "POST",
          body: JSON.stringify(validationResult.data),
       });
 
-      console.log(response);
       return {
          success: true,
-         accessToken: response.mover.accessToken,
-         user: response.mover.user,
+         accessToken: response.data.accessToken,
+         user: response.data.user,
       };
    } catch (error: unknown) {
       console.error("회원가입 실패 원인: ", error);

--- a/src/lib/actions/auth/create-mover-local-signup.action.ts
+++ b/src/lib/actions/auth/create-mover-local-signup.action.ts
@@ -1,19 +1,19 @@
 "use server";
 
 import { defaultFetch } from "@/lib/api/fetch-client";
-import { AuthActionResult, AuthValidation } from "@/lib/types/auth.type";
+import { AuthActionResult } from "@/lib/types/auth.type";
 import isFetchError from "@/lib/utils/fetch-error.util";
 import { signUpFormSchema } from "@/lib/validations/auth.schemas";
 
 export default async function createMoverLocalSignupAction(
-   _: AuthValidation | null,
+   _: AuthActionResult | null,
    formData: FormData,
 ): Promise<AuthActionResult> {
    try {
       const rawFormData = {
          name: formData.get("name")?.toString() ?? "",
          email: formData.get("email")?.toString() ?? "",
-         phone: formData.get("phoneNumber")?.toString() ?? "",
+         phone: formData.get("phone")?.toString() ?? "",
          password: formData.get("password")?.toString() ?? "",
          passwordConfirmation:
             formData.get("passwordConfirmation")?.toString() ?? "",
@@ -44,12 +44,13 @@ export default async function createMoverLocalSignupAction(
          body: JSON.stringify(validationResult.data),
       });
 
+      console.log(response);
       return {
          success: true,
          accessToken: response.mover.accessToken,
          user: response.mover.user,
       };
-   } catch (error) {
+   } catch (error: unknown) {
       console.error("회원가입 실패 원인: ", error);
 
       // ✅ BE 오류 받음 (이메일, 전화번호 중복)

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,8 +10,7 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 환경 변수 설정해서 쓰세요.
-export const BASE_URL = "https://sixth-moving-4team-be.onrender.com";
-// process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
+export const BASE_URL = "http://localhost:4000";
 
 // ✅ 서버에서 던진 오류 받기: 문자 형태, 객체 형태(data로 받음)
 async function handleResponse(response: Response) {
@@ -58,9 +57,6 @@ export async function defaultFetch(
 
    // ★ 응답
    try {
-      //디버깅
-      console.log("url", url);
-
       const response = await fetch(url, {
          ...options,
          headers,

--- a/src/lib/api/fetch-client.ts
+++ b/src/lib/api/fetch-client.ts
@@ -10,7 +10,8 @@ import { accessTokenSettings } from "../utils/auth.util";
 import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 환경 변수 설정해서 쓰세요.
-export const BASE_URL = "http://localhost:4000";
+export const BASE_URL =
+   process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 // ✅ 서버에서 던진 오류 받기: 문자 형태, 객체 형태(data로 받음)
 async function handleResponse(response: Response) {


### PR DESCRIPTION
## 작업 개요
- 기사님 로그인, 회원가입 fetch 연동

---

## 작업 상세 내용
- [x] 프로필 생성 페이지 분기처리 로직 수정
- [x] 프론트에서 로컬 로그인, 회원가입 로직 수정
- [x] 데이터 응답 형태 맞춤

---

## 🗂️ 수정한 파일
- `src/componets/landing/layout/LandingHeader.tsx` (로그인, 로그아웃 경로 수정)
- `src/app/(with-protected)/profile/create/page.tsx`  (분기처리 로직 수정)
- `src.components/sign-up-in/MoverLoginForm.tsx`  (로그인성공 시 리다이렉트 로직 추가)

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항

