### PR TITLE
fix: 프로필 페이지 작업 및 전역상태관리 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
    images: {
-      domains: ["www.zimssa.com", "i.namu.wiki"], // 외부 이미지 호스트 허용
+      domains: ["www.zimssa.com"], // 외부 이미지 호스트 허용
    },
    webpack(config) {
       config.module.rules.push({

--- a/src/app/(with-protected)/profile/ClientProfileForm.tsx
+++ b/src/app/(with-protected)/profile/ClientProfileForm.tsx
@@ -1,0 +1,19 @@
+// import ProfileImage from "@/components/profile/ProfileImage";
+import React from "react";
+
+const titleStyle = "text-black-300 text-16-semibold lg:text-20-semibold";
+
+export default function ClientProfileForm() {
+   return (
+      <>
+         {/* 이미지 */}
+         <section className="mb-6">
+            <p className={titleStyle}>프로필 이미지</p>
+            {/* <ProfileImage /> */}
+         </section>
+
+         <section></section>
+         <section></section>
+      </>
+   );
+}

--- a/src/app/(with-protected)/profile/create/page.tsx
+++ b/src/app/(with-protected)/profile/create/page.tsx
@@ -1,10 +1,25 @@
 "use client";
 
-import MoverProfileForm from "@/components/profile/MoverProfileForms";
+import React from "react";
 import { useAuth } from "@/context/AuthContext";
+import ClientProfileTitle from "@/components/profile/ClientProfileTitle";
+import MoverProfileForm from "@/components/profile/MoverProfileForm";
+import ClientProfileForm from "../ClientProfileForm";
 
 export default function CreateProfilePage() {
    const { user } = useAuth();
+
+   //일반으로 로그인한 회원의 경우
+   if (user?.userType === "client") {
+      return (
+         <div className="pt-4 pb-10 lg:pt-6">
+            <div className="mx-auto flex max-w-82 flex-col gap-4 lg:max-w-160 lg:gap-6">
+               <ClientProfileTitle />
+               <ClientProfileForm />
+            </div>
+         </div>
+      );
+   }
 
    //기사님으로 로그인한 회원의 경우
    if (user!.userType === "mover") {

--- a/src/app/(with-protected)/profile/create/page.tsx
+++ b/src/app/(with-protected)/profile/create/page.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { useAuth } from "@/context/AuthContext";
 import ClientProfileTitle from "@/components/profile/ClientProfileTitle";
-import MoverProfileForm from "@/components/profile/MoverProfileForm";
+import MoverProfileForm from "@/components/profile/MoverProfileForms";
 import ClientProfileForm from "../ClientProfileForm";
 
 export default function CreateProfilePage() {

--- a/src/components/layout/HeaderProfile.tsx
+++ b/src/components/layout/HeaderProfile.tsx
@@ -36,7 +36,7 @@ export default function HeaderProfile() {
          {user && (
             <figure className={`${iconStyle} overflow-hidden rounded-full`}>
                <Image
-                  src={user.profile || profileIcon}
+                  src={user.profileImage || profileIcon}
                   alt="프로필 아이콘"
                   fill
                   className="object-cover"

--- a/src/components/layout/HeaderSideBarMenu.tsx
+++ b/src/components/layout/HeaderSideBarMenu.tsx
@@ -30,7 +30,7 @@ export default function HeaderSideBarMenu({ onClick }: Prop) {
                   <Image src={xIcon} alt="x 아이콘" width={24} height={24} />
                </button>
             </div>
-
+            <>{console.log(user)}</>
             <nav>
                {!user && (
                   <>

--- a/src/components/profile/ClientProfileTitle.tsx
+++ b/src/components/profile/ClientProfileTitle.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function ClientProfileTitle() {
+   return (
+      <section>
+         <p className="text-black-400 text-18-bold lg:text-32-medium">
+            프로필 등록
+         </p>
+         <p className="text-black-100 text-12-regular lg:text-20-regular">
+            추가 정보를 입력하여 회원가입을 완료해주세요.
+         </p>
+         <hr className="border-line-100 border-b" />
+      </section>
+   );
+}

--- a/src/components/profile/ProfileImage.tsx
+++ b/src/components/profile/ProfileImage.tsx
@@ -1,0 +1,21 @@
+// "use client";
+
+// import React from "react";
+// import Image from "next/image";
+// import profileUploaderIcon from "@/assets/images/profileUploaderIcon.svg";
+// import { useAuth } from "@/context/AuthContext";
+
+// export default function ProfileImage() {
+//    const { user } = useAuth();
+
+//    return (
+//       <figure className="relative h-25 w-25 lg:h-80 lg:w-80">
+//          <Image
+//             src={user ? user.profileImage : profileUploaderIcon}
+//             alt="프로필 이미지"
+//             fill
+//             // onClick={}
+//          />
+//       </figure>
+//    );
+// }

--- a/src/components/sign-up-in/ClientLoginForm.tsx
+++ b/src/components/sign-up-in/ClientLoginForm.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { validateAuthEmail, validateAuthPassword } from "@/lib/validations";
 import createClientLocalLoginAction from "@/lib/actions/auth/create-client-local-login.action";
+import { User } from "@/lib/types";
 
 export default function ClientLoginForm() {
    // 상태 모음
@@ -47,7 +48,9 @@ export default function ClientLoginForm() {
    // ✅ 로그인 성공하면 페이지 이동
    useEffect(() => {
       if (formState?.success && formState.user && formState?.accessToken) {
-         login(formState.user, formState.accessToken);
+         const rawUser = formState.user as User;
+
+         login(rawUser, formState.accessToken);
          router.push("/mover-search");
       }
    }, [formState, login, router]);

--- a/src/components/sign-up-in/MoverLoginForm.tsx
+++ b/src/components/sign-up-in/MoverLoginForm.tsx
@@ -10,6 +10,7 @@ import { validateAuthEmail, validateAuthPassword } from "@/lib/validations";
 import createMoverLocalLoginAction from "@/lib/actions/auth/create-mover-local-login.action";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
+import { User } from "@/lib/types";
 
 export default function MoverLoginForm() {
    const router = useRouter();
@@ -47,7 +48,9 @@ export default function MoverLoginForm() {
    //로그인 성공 시 프로필 생성 페이지로 리다이렉트
    useEffect(() => {
       if (formState?.success && formState.user && formState?.accessToken) {
-         login(formState.user, formState.accessToken);
+         const rawUser = formState.user as User;
+
+         login(rawUser, formState.accessToken);
          router.push("/profile/create");
       }
    }, [formState, login, router]);

--- a/src/components/sign-up-in/MoverSignUpForm.tsx
+++ b/src/components/sign-up-in/MoverSignUpForm.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/validations";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import { AuthValidationResult } from "@/lib/types";
+import { AuthValidationResult, User } from "@/lib/types";
 import createMoverLocalSignupAction from "@/lib/actions/auth/create-mover-local-signup.action";
 
 export default function MoverSignUpForm() {
@@ -89,8 +89,10 @@ export default function MoverSignUpForm() {
    //회원가입 성공 시 리다이렉트
    useEffect(() => {
       if (formState?.success && formState.accessToken && formState.user) {
-         login(formState.user, formState.accessToken);
-         location.href = "/profile/create";
+         const rawUser = formState.user as User;
+
+         login(rawUser, formState.accessToken);
+         router.push("/profile/create");
       }
    }, [formState, login, router]);
 

--- a/src/lib/hooks/useUser.tsx
+++ b/src/lib/hooks/useUser.tsx
@@ -1,0 +1,16 @@
+import { useAuth } from "@/context/AuthContext";
+import { isClient, isMover } from "@/lib/types/auth.type";
+
+// userType 보는 함수
+export function useUser() {
+   const { user, ...rest } = useAuth();
+
+   return {
+      user,
+      isClient: user ? isClient(user) : false,
+      isMover: user ? isMover(user) : false,
+      clientUser: user && isClient(user) ? user : null,
+      moverUser: user && isMover(user) ? user : null,
+      ...rest,
+   };
+}

--- a/src/lib/types/auth.type.ts
+++ b/src/lib/types/auth.type.ts
@@ -1,13 +1,43 @@
-// userType
-export type UserType = "guest" | "client" | "mover";
+// ✅ userType
+export type UserType = "client" | "mover";
 
-// 그냥 불러올 User 정보 (헤더)
-export interface User {
+// ✅ 불러올 사용자 정보
+interface BaseUser {
    userType: UserType;
    id: string;
    email: string;
    name: string;
-   profile?: string;
+   phone?: string;
+   profileImage?: string;
+   isProfileCompleted: boolean;
+}
+
+interface Client extends BaseUser {
+   serviceType: string[];
+   livingArea: string[];
+}
+
+interface Mover extends BaseUser {
+   nickName?: string;
+   career?: number;
+   introduction?: string;
+   description?: string;
+   serviceType: string[];
+   serviceArea: string[];
+   favoriteCount: number;
+   estimateCount: number;
+   reviewCount: number;
+}
+
+export type User = Client | Mover;
+
+// ✅ Type Guard 함수
+export function isClient(user: User): user is Client {
+   return user.userType === "client";
+}
+
+export function isMover(user: User): user is Mover {
+   return user.userType === "mover";
 }
 
 // 유효성 검사용 type 모음
@@ -20,7 +50,7 @@ export type AuthValidationResult = {
 export type AuthValidation = {
    success: boolean;
    error?: string | Record<string, string>;
-   user?: User;
+   user?: BaseUser;
    accessToken?: string;
 };
 
@@ -41,7 +71,7 @@ export interface ErrorsState {
 // Server Action 응답
 export interface AuthActionResult {
    success: boolean;
-   user?: User;
+   user?: BaseUser;
    accessToken?: string;
    fieldErrors?: Record<string, string>;
    globalError?: string;


### PR DESCRIPTION
## 작업 개요
- 제목 그대로 프로필 페이지 작업하다가 전역상태관리가 급해서 먼저 PR 올렸습니다.

---

## 작업 상세 내용
- [x] User type 확장
- [x] 상기의 이유로 인증 쪽 페이지에 생긴 오류 수정
- [ ] 프로필 만들다가 중단

---

## 🗂️ 수정한 파일
- `src/lib/types/auth.type.ts`
- `src/components/sign-up-in/MoverSignUpForm.tsx`
- `src/components/sign-up-in/MoverLoginForm.tsx`
- `src/components/sign-up-in/ClientLoginForm.tsx`

---

## 🗂️ 새로 작성한 파일
- `src/lib/hooks/useUser.tsx`
- `src/components/Footer.tsx`

---

## 기타 참고 사항
- 지금 HeaderSideBarMenu에 console.log 있는 것 발견했는데 다음 PR 때 지워서 반영하겠습니다.
