### PR TITLE
fix: 대기 중인 견적 기사 프로필 상세 정보 수정

### DIFF
--- a/src/app/(with-protected)/my-quotes/client/[id]/page.tsx
+++ b/src/app/(with-protected)/my-quotes/client/[id]/page.tsx
@@ -10,77 +10,106 @@ import MoverProfileClient from "@/components/my-quotes/common/MoverProfileClient
 
 // 견적 관리 상세
 export default async function Page() {
-  return (
-    <div>
-      <PageTitle title="견적 상세" />
-      <div className="flex item justify-between">
-        <section className="w-full flex flex-col items gap-6 mt-2 mb-27 lg:max-w-238.5 lg:mt-6 lg:gap-10">
-          <article className="bg-white border border-line-100 rounded-2xl px-3.5 py-4 lg:px-6 lg:py-5">
-            <MoverProfileClient />
-          </article>
-          <hr className="h-px bg-line-100 border-0" />
-          <article>
-            <p className="text-16-semibold mb-4 lg:text-24-semibold">견적가</p>
-            <p className="text-20-bold lg:text-32-bold">180,000원</p>
-          </article>
-          <hr className="h-px bg-line-100 border-0" />
-          <article className="lg:hidden">
-            <p className="text-14-semibold mb-4 md:text-16-semibold">
-              견적서 공유하기
-            </p>
-            <div className="flex items-center gap-4">
-              <Image src={shareLink} alt="링크 공유" width={40} height={40} />
-              <Image
-                src={shareKakao}
-                alt="카카오 공유"
-                width={40}
-                height={40}
-              />
-              <Image
-                src={shareFacebook}
-                alt="페이스북 공유 공유"
-                width={40}
-                height={40}
-              />
+   return (
+      <div>
+         <PageTitle title="견적 상세" />
+         <div className="item flex justify-between">
+            <section className="items mt-2 mb-27 flex w-full flex-col gap-6 lg:mt-6 lg:max-w-238.5 lg:gap-10">
+               <article className="border-line-100 rounded-2xl border bg-white px-3.5 py-4 lg:px-6 lg:py-5">
+                  <MoverProfileClient
+                     moveType="HOME"
+                     isDesignated={true}
+                     moverName="홍길동 이사님"
+                     profileImage={null}
+                     isFavorited={false}
+                     averageReviewRating={4.8}
+                     reviewCount={12}
+                     career={5}
+                     estimateCount={120}
+                     favoriteCount={30}
+                     quotesStatus="received"
+                  />
+               </article>
+               <hr className="bg-line-100 h-px border-0" />
+               <article>
+                  <p className="text-16-semibold lg:text-24-semibold mb-4">
+                     견적가
+                  </p>
+                  <p className="text-20-bold lg:text-32-bold">180,000원</p>
+               </article>
+               <hr className="bg-line-100 h-px border-0" />
+               <article className="lg:hidden">
+                  <p className="text-14-semibold md:text-16-semibold mb-4">
+                     견적서 공유하기
+                  </p>
+                  <div className="flex items-center gap-4">
+                     <Image
+                        src={shareLink}
+                        alt="링크 공유"
+                        width={40}
+                        height={40}
+                     />
+                     <Image
+                        src={shareKakao}
+                        alt="카카오 공유"
+                        width={40}
+                        height={40}
+                     />
+                     <Image
+                        src={shareFacebook}
+                        alt="페이스북 공유 공유"
+                        width={40}
+                        height={40}
+                     />
+                  </div>
+               </article>
+               <hr className="bg-line-100 h-px border-0 lg:hidden" />
+               <QuotaionInfo />
+            </section>
+            <div
+               style={{ boxShadow: "0px 4px 8px 0px rgba(0, 0, 0, 0.16)" }}
+               className="fixed bottom-0 left-0 flex w-full items-center gap-2 bg-white px-6 py-2.5 md:px-16 lg:hidden"
+            >
+               <div className="border-line-200 flex h-13.5 w-13.5 flex-shrink-0 cursor-pointer items-center justify-center rounded-2xl border">
+                  <Image
+                     src={likeIcon}
+                     alt="좋아요 버튼"
+                     width={24}
+                     height={24}
+                  />
+               </div>
+               <SolidButton>견적 확정하기</SolidButton>
             </div>
-          </article>
-          <hr className="h-px bg-line-100 border-0 lg:hidden" />
-          <QuotaionInfo />
-        </section>
-        <div
-          style={{ boxShadow: "0px 4px 8px 0px rgba(0, 0, 0, 0.16)" }}
-          className="fixed bottom-0 left-0 w-full px-6 py-2.5 flex items-center gap-2 bg-white md:px-16 lg:hidden"
-        >
-          <div className="w-13.5 h-13.5 flex-shrink-0 border border-line-200 rounded-2xl flex items-center justify-center cursor-pointer">
-            <Image src={likeIcon} alt="좋아요 버튼" width={24} height={24} />
-          </div>
-          <SolidButton>견적 확정하기</SolidButton>
-        </div>
-        <div className="hidden lg:block w-82">
-          <SolidButton>견적 확정하기</SolidButton>
-          <hr className="h-px bg-line-100 border-0 my-10" />
-          <article>
-            <p className="text-14-semibold mb-4 md:text-16-semibold lg:text-20-semibold">
-              견적서 공유하기
-            </p>
-            <div className="flex items-center gap-4">
-              <Image src={shareLink} alt="링크 공유" width={64} height={64} />
-              <Image
-                src={shareKakao}
-                alt="카카오 공유"
-                width={64}
-                height={64}
-              />
-              <Image
-                src={shareFacebook}
-                alt="페이스북 공유 공유"
-                width={64}
-                height={64}
-              />
+            <div className="hidden w-82 lg:block">
+               <SolidButton>견적 확정하기</SolidButton>
+               <hr className="bg-line-100 my-10 h-px border-0" />
+               <article>
+                  <p className="text-14-semibold md:text-16-semibold lg:text-20-semibold mb-4">
+                     견적서 공유하기
+                  </p>
+                  <div className="flex items-center gap-4">
+                     <Image
+                        src={shareLink}
+                        alt="링크 공유"
+                        width={64}
+                        height={64}
+                     />
+                     <Image
+                        src={shareKakao}
+                        alt="카카오 공유"
+                        width={64}
+                        height={64}
+                     />
+                     <Image
+                        src={shareFacebook}
+                        alt="페이스북 공유 공유"
+                        width={64}
+                        height={64}
+                     />
+                  </div>
+               </article>
             </div>
-          </article>
-        </div>
+         </div>
       </div>
-    </div>
-  );
+   );
 }

--- a/src/components/my-quotes/common/MoverProfileClient.tsx
+++ b/src/components/my-quotes/common/MoverProfileClient.tsx
@@ -3,29 +3,47 @@
 import MoveChip from "@/components/common/chips/MoveChip";
 import MoverProfile from "@/components/common/profile/MoverProfile";
 import profile from "@/assets/images/profileIcon.svg";
+import { ChipType } from "@/lib/types";
 
-export default function MoverProfileclient() {
-  return (
-    <article className=" flex flex-col gap-3.5 ">
-      <div className="flex items-center gap-2">
-        <MoveChip type="PENDING" />
-        <MoveChip type="SMALL" />
-        <MoveChip type="DESIGNATED" />
-      </div>
-      <p className="text-14-semibold text-black-300 lg:text-20-semibold">
-        고객님의 물품을 안전하게 운송해 드립니다.
-      </p>
-      <MoverProfile
-        nickName="이삿짐킹"
-        profileImage={profile}
-        isLiked={false}
-        handleLikedClick={() => console.log("찜 토글")}
-        favoriteCount={24}
-        averageReviewRating={4.8}
-        reviewCount={37}
-        career={7}
-        estimateCount={120}
-      />
-    </article>
-  );
+interface MoverProfileclientProps {
+   moveType: ChipType;
+   isDesignated: boolean;
+   moverName: string;
+   profileImage: string | null;
+   isFavorited: boolean;
+   handleLikedClick?: () => void;
+   averageReviewRating: number;
+   reviewCount: number;
+   career: number;
+   estimateCount: number;
+   favoriteCount: number;
+   quotesStatus: "pending" | "received";
+}
+
+export default function MoverProfileclient(props: MoverProfileclientProps) {
+   return (
+      <article className="flex flex-col gap-3.5">
+         <div className="flex items-center gap-2">
+            {props.quotesStatus === "pending" && <MoveChip type="PENDING" />}
+            {props.moveType && <MoveChip type={props.moveType as ChipType} />}
+            {props.isDesignated && <MoveChip type="DESIGNATED" />}
+         </div>
+         <p
+            className={`text-14-semibold text-black-300 lg:text-20-semibold ${props.quotesStatus === "pending" ? "hidden" : "block"}`}
+         >
+            고객님의 물품을 안전하게 운송해 드립니다.
+         </p>
+         <MoverProfile
+            nickName={props.moverName}
+            profileImage={props.profileImage || profile}
+            isLiked={!!props.isFavorited}
+            handleLikedClick={() => console.log("찜 토글")}
+            averageReviewRating={props.averageReviewRating}
+            reviewCount={props.reviewCount}
+            career={props.career | 0}
+            estimateCount={props.estimateCount}
+            favoriteCount={props.favoriteCount}
+         />
+      </article>
+   );
 }

--- a/src/components/my-quotes/common/ReceivedCard.tsx
+++ b/src/components/my-quotes/common/ReceivedCard.tsx
@@ -3,19 +3,31 @@
 import MoverProfileclient from "./MoverProfileClient";
 
 export default function ReceivedCard() {
-  return (
-    <div
-      style={{
-        boxShadow:
-          "-2px -2px 10px rgba(220, 220, 220, 0.2), 2px 2px 10px rgba(220, 220, 220, 0.14)",
-      }}
-      className="bg-white px-3.5 lg:px-6 pt-5 lg:pt-7 pb-3.5 lg:pb-5.5 w-full flex flex-col gap-2 rounded-2xl cursor-pointer"
-    >
-      <MoverProfileclient />
-      <div className="flex items-center justify-end gap-2">
-        <p className="text-14-medium lg:text-18-medium">견적금액</p>
-        <p className="text-18-bold lg:text-24-bold">180,000원</p>
+   return (
+      <div
+         style={{
+            boxShadow:
+               "-2px -2px 10px rgba(220, 220, 220, 0.2), 2px 2px 10px rgba(220, 220, 220, 0.14)",
+         }}
+         className="flex w-full cursor-pointer flex-col gap-2 rounded-2xl bg-white px-3.5 pt-5 pb-3.5 lg:px-6 lg:pt-7 lg:pb-5.5"
+      >
+         <MoverProfileclient
+            moveType="HOME"
+            isDesignated={true}
+            moverName="홍길동 이사님"
+            profileImage={null}
+            isFavorited={false}
+            averageReviewRating={4.8}
+            reviewCount={12}
+            career={5}
+            estimateCount={120}
+            favoriteCount={30}
+            quotesStatus="received"
+         />
+         <div className="flex items-center justify-end gap-2">
+            <p className="text-14-medium lg:text-18-medium">견적금액</p>
+            <p className="text-18-bold lg:text-24-bold">180,000원</p>
+         </div>
       </div>
-    </div>
-  );
+   );
 }

--- a/src/components/my-quotes/pages/Pending.tsx
+++ b/src/components/my-quotes/pages/Pending.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import MoveChip from "@/components/common/chips/MoveChip";
-import MoverProfile from "@/components/common/profile/MoverProfile";
 import profile from "@/assets/images/profileIcon.svg";
 import MoveDateCard from "../common/MoveDateCard";
 import SolidButton from "@/components/common/buttons/SolidButton";
@@ -12,67 +10,8 @@ import { fetchPendingQuotes } from "@/lib/api/my-quotes/getMyQuotes";
 import { pendingQuote } from "@/lib/types/quotes.types";
 import emptyQuotes from "@/assets/images/emptyBlueFolderIcon.svg";
 import Image from "next/image";
-
-// const data = [
-//    {
-//       requestId: "a818fac9-ce84-4440-bfa4-71a89438d7da",
-//       moveDate: "2025-08-01T09:00:00.000Z",
-//       fromAddress: "서울 강남구 테헤란로 1",
-//       toAddress: "경기 성남시 분당구 판교로 1",
-//       estimates: [
-//          {
-//             estimateId: "c562bd92-367f-4178-b39f-6348348b40b8",
-//             moverId: "a61f9424-1df9-40d8-aabd-bc4e18103639",
-//             moverName: "기사1",
-//             moverNickName: "이사짱1",
-//             profileImage: null,
-//             comment: "엘리베이터 있음, 짐 많음",
-//             price: 250000,
-//             created: "2025-07-14T11:30:32.131Z",
-//             isDesignated: true,
-//             isFavorited: {
-//                id: "419fe731-bf24-4773-99a0-5e8764850d8e",
-//                clientId: "6328af51-4c80-4ec2-a5d7-809a2a3dc5ad",
-//                moverId: "a61f9424-1df9-40d8-aabd-bc4e18103639",
-//             },
-//          },
-//          {
-//             estimateId: "d0b6bc91-5ad0-447a-b307-293ad2ebdc48",
-//             moverId: "83aef138-0eaa-4c06-8869-5fa19583b530",
-//             moverName: "무버",
-//             moverNickName: null,
-//             profileImage: null,
-//             comment: "나 김정은인데 남한으로 이사가고 싶엉",
-//             price: 10,
-//             created: "2025-07-15T15:15:03.257Z",
-//             isDesignated: false,
-//             isFavorited: null,
-//          },
-//       ],
-//    },
-//    {
-//       requestId: "6ff26996-b5d9-4b69-808a-4adc47ee5eb8",
-//       moveDate: "2025-07-09T00:00:00.000Z",
-//       fromAddress: "대전 서구 가수원로 17-19",
-//       toAddress: "부산 해운대구 구남로 5",
-//       estimates: [
-//          {
-//             estimateId: "d0b6bc91-5ad0-447a-b307-293ad2ebdc43",
-//             moverId: "83aef138-0eaa-4c06-8869-5fa19583b530",
-//             moverName: "무버",
-//             moverNickName: null,
-//             profileImage: null,
-//             comment: "나 김정은인데 남한으로 이사가고 싶엉",
-//             price: 10,
-//             created: "2025-07-15T15:15:03.257Z",
-//             isDesignated: false,
-//             isFavorited: null,
-//          },
-//       ],
-//    },
-// ];
-
-// 대기중인 견적
+import { ChipType } from "@/lib/types";
+import MoverProfileclient from "../common/MoverProfileClient";
 
 export default function Pending() {
    const [data, setData] = useState<pendingQuote[]>();
@@ -111,24 +50,19 @@ export default function Pending() {
                   className="mx-auto flex w-full flex-col gap-2 rounded-2xl bg-white px-3 pt-5 pb-3.5 lg:mx-0 lg:w-172 lg:px-6 lg:pt-7 lg:pb-5.5"
                >
                   <div className="flex flex-col gap-3.5">
-                     <article className="flex items-center gap-2">
-                        {/* todo: moveType 추가하기 */}
-                        <MoveChip type="PENDING" />
-                        {estimate.isDesignated && (
-                           <MoveChip type="DESIGNATED" />
-                        )}
-                     </article>
-                     <MoverProfile
-                        nickName={estimate.moverNickName || estimate.moverName}
+                     <MoverProfileclient
+                        moveType={request.moveType as ChipType}
+                        isDesignated={estimate.isDesignated}
+                        moverName={estimate.moverName}
                         profileImage={estimate.profileImage || profile}
-                        isLiked={!!estimate.isFavorited}
+                        isFavorited={!!estimate.isFavorited}
                         handleLikedClick={() => console.log("찜 토글")}
-                        // todo: 기사님 상세 정보 추가하기
-                        averageReviewRating={4.5}
-                        reviewCount={3}
-                        career={7}
-                        estimateCount={171}
-                        favoriteCount={5}
+                        averageReviewRating={estimate.reviewRating}
+                        reviewCount={estimate.reviewCount}
+                        career={estimate.career | 0}
+                        estimateCount={estimate.estimateCount}
+                        favoriteCount={estimate.favoriteCount}
+                        quotesStatus="pending"
                      />
                      <MoveDateCard
                         category="이사일"
@@ -158,7 +92,7 @@ export default function Pending() {
                      <SolidButton>견적 확정하기</SolidButton>
                      <OutlinedButton
                         onClick={() =>
-                           router.push(`my-quotes/${request.requestId}`)
+                           router.push(`client/${request.requestId}`)
                         }
                      >
                         상세보기

--- a/src/lib/api/my-quotes/getMyQuotes.ts
+++ b/src/lib/api/my-quotes/getMyQuotes.ts
@@ -1,5 +1,5 @@
 import { tokenFetch } from "../fetch-client";
 
 export async function fetchPendingQuotes() {
-   return await tokenFetch("/estimates/estimates/pending", { method: "GET" });
+   return await tokenFetch("/estimates/pending", { method: "GET" });
 }

--- a/src/lib/types/quotes.types.ts
+++ b/src/lib/types/quotes.types.ts
@@ -14,7 +14,12 @@ export interface Estimate {
    price: number;
    created: string;
    isDesignated: boolean;
-   isFavorited: Favorite | null;
+   isFavorited: Favorite;
+   career: number;
+   estimateCount: number;
+   favoriteCount: number;
+   reviewCount: number;
+   reviewRating: number;
 }
 
 export interface pendingQuote {
@@ -22,5 +27,6 @@ export interface pendingQuote {
    fromAddress: string;
    toAddress: string;
    moveDate: string;
+   moveType: string;
    estimates: Estimate[];
 }


### PR DESCRIPTION
## 작업 개요
- 대기 중인 견적 기사 프로필 상세 정보 수정

---

## 작업 상세 내용
- [x] 대기 중인 견적 기사 프로필 상세 정보 호출 후 수정
- [x] 변경된 api 주소로 연결
- [x] 견적 페이지 기사님 프로필 컴포넌트화

---

## 🗂️ 수정한 파일
- `src/app/(with-protected)/my-quotes/client/page.tsx`
- `src/components/my-quotes/common/MoverProfileClient.tsx`
- `src/components/my-quotes/common/MoverReceivedCard.tsx`
- `src/components/my-quotes/page/Pending.tsx`
- `src/lib/api/my-quotes/getMyQuotes.ts`
- `src/lib/api/types/quotes.types.ts`
---

## 🗂️ 새로 작성한 파일
X

---

## 기타 참고 사항
- 
