### PR TITLE
refector: 기사님 회원가입 & 로그인 폴더 구조 적용

### DIFF
--- a/src/app/(with-guest)/sign-in/mover/page.tsx
+++ b/src/app/(with-guest)/sign-in/mover/page.tsx
@@ -1,17 +1,18 @@
-// import EasyLoginForm from "@/components/sign-up-in/EasyLoginForm";
-// import MoverTitle from "@/components/sign-up-in/MoverTitle";
-// import MoverLoginForm from "@/components/sign-up-in/MoverLoginForm";
+import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
+import MoverTitle from "@/components/domain/auth/MoverTitle";
+import SignInForm from "@/components/domain/auth/SignInForm";
 
 export default function MoverSignInPage() {
-   return <></>;
-   //       <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
-   //          {/* 제목 + 기사 페이지로 링크 이동 */}
-   //          <MoverTitle type="login" />
+   return (
+      <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
+         {/* 제목 + 일반유저 페이지로 링크 이동 */}
+         <MoverTitle type="login" />
 
-   //          {/* 서식 */}
-   //          <MoverLoginForm />
+         {/* 서식 */}
+         <SignInForm userType="mover" />
 
-   //          {/* 간편 회원가입 */}
-   //          <EasyLoginForm />
-   //       </section>
+         {/* 간편 회원가입 */}
+         <EasyLoginForm />
+      </section>
+   );
 }

--- a/src/app/(with-guest)/sign-up/mover/page.tsx
+++ b/src/app/(with-guest)/sign-up/mover/page.tsx
@@ -1,19 +1,18 @@
-// import EasyLoginForm from "@/components/sign-up-in/EasyLoginForm";
-// import MoverSignUpForm from "@/components/sign-up-in/MoverSignUpForm";
-// import MoverTitle from "@/components/sign-up-in/MoverTitle";
+import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
+import MoverTitle from "@/components/domain/auth/MoverTitle";
+import SignUpForm from "@/components/domain/auth/SignUpForm";
 
 export default function MoverSignUpPage() {
-   return <></>;
-   // (
-   //       <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
-   //          {/* 제목 + 기사 페이지로 링크 이동 */}
-   //          <MoverTitle type="signup" />
+   return (
+      <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
+         {/* 제목 + 기사 페이지로 링크 이동 */}
+         <MoverTitle type="signup" />
 
-   //          {/* 서식 */}
-   //          <MoverSignUpForm />
+         {/* 서식 */}
+         <SignUpForm userType="mover" />
 
-   //          {/* 간편 회원가입 */}
-   //          <EasyLoginForm />
-   //       </section>
-   //    );
+         {/* 간편 회원가입 */}
+         <EasyLoginForm />
+      </section>
+   );
 }

--- a/src/app/(with-protected)/dashboard/edit-account/page.tsx
+++ b/src/app/(with-protected)/dashboard/edit-account/page.tsx
@@ -1,3 +1,19 @@
-export default function Page() {
-   return <div>page</div>;
+import BasicInfoForms from "@/components/domain/dashboard/BasicInfoForms";
+
+export default function MoverBasicInfoEditPage() {
+   return (
+      <>
+         <div className="mb-6 flex flex-col gap-4 lg:mb-12 lg:gap-8">
+            <div className="text-18-semibold lg:text-32-semibold leading-8">
+               기본정보 수정
+            </div>
+         </div>
+
+         <hr className="border-line-100 m-0 border-t p-0" />
+
+         <div className="mt-10">
+            <BasicInfoForms />
+         </div>
+      </>
+   );
 }

--- a/src/app/(with-protected)/profile/create/page.tsx
+++ b/src/app/(with-protected)/profile/create/page.tsx
@@ -22,7 +22,7 @@ export default function CreateProfilePage() {
    }
 
    //기사님으로 로그인한 회원의 경우
-   if (user!.userType === "mover") {
+   if (user?.userType === "mover") {
       return (
          <>
             <div className="mb-6 flex flex-col gap-4 lg:mb-12 lg:gap-8">

--- a/src/app/(with-protected)/profile/create/page.tsx
+++ b/src/app/(with-protected)/profile/create/page.tsx
@@ -3,8 +3,8 @@
 import React from "react";
 import { useAuth } from "@/context/AuthContext";
 import ClientProfileTitle from "@/components/domain/profile/ClientProfileTitle";
-// import MoverProfileForm from "@/components/domain/profile/MoverProfileForms";
 import ClientProfilePostForm from "@/components/domain/profile/ClientProfilePostForm";
+import MoverProfilePostForm from "@/components/domain/profile/MoverProfilePostForms";
 
 export default function CreateProfilePage() {
    const { user } = useAuth();
@@ -22,25 +22,25 @@ export default function CreateProfilePage() {
    }
 
    //기사님으로 로그인한 회원의 경우
-   // if (user!.userType === "mover") {
-   //    return (
-   //       <>
-   //          <div className="mb-6 flex flex-col gap-4 lg:mb-12 lg:gap-8">
-   //             <div className="text-18-semibold lg:text-32-semibold leading-8">
-   //                기사님 프로필 등록
-   //             </div>
+   if (user!.userType === "mover") {
+      return (
+         <>
+            <div className="mb-6 flex flex-col gap-4 lg:mb-12 lg:gap-8">
+               <div className="text-18-semibold lg:text-32-semibold leading-8">
+                  기사님 프로필 등록
+               </div>
 
-   //             <div className="lg:text-20-regular text-12-regular text-black-200 leading-8">
-   //                추가 정보를 입력하여 회원가입을 완료해주세요
-   //             </div>
-   //          </div>
+               <div className="lg:text-20-regular text-12-regular text-black-200 leading-8">
+                  추가 정보를 입력하여 회원가입을 완료해주세요
+               </div>
+            </div>
 
-   //          <hr className="border-line-100 m-0 border-t p-0" />
+            <hr className="border-line-100 m-0 border-t p-0" />
 
-   //          <MoverProfileForm />
-   //       </>
-   //    );
-   // }
+            <MoverProfilePostForm />
+         </>
+      );
+   }
 
    // 그외 예상치 못한 userType
    return (

--- a/src/components/domain/auth/MoverTitle.tsx
+++ b/src/components/domain/auth/MoverTitle.tsx
@@ -1,29 +1,32 @@
-// import React from "react";
-// import Link from "next/link";
-// import Image from "next/image";
-// import logo from "@/assets/images/logoText.svg";
-// import { MoverAuthProps } from "@/lib/types";
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+import logo from "@/assets/images/logoText.svg";
 
-// // 회원가입 & 로그인 페이지 제목 로고 및 링크 (일반 회원)
-// export default function MoverTitle({ type }: MoverAuthProps) {
-//    return (
-//       <div className="mb-10">
-//          <Link href="/mover-search">
-//             <figure className="relative mx-auto h-11 w-22 lg:h-13 lg:w-26">
-//                <Image src={logo} alt="무빙 로고" fill />
-//             </figure>
-//          </Link>
-//          <div className="lg:mt- mt-4 flex gap-1 lg:gap-2">
-//             <p className="text-black-100 text-12-regular lg:text-20-regular">
-//                일반 유저라면?
-//             </p>
-//             <Link
-//                href={type === "login" ? "/sign-in/client" : "/sign-up/client"}
-//                className="text-primary-blue-300 text-12-semibold lg:text-20-semibold underline"
-//             >
-//                일반 유저 전용 페이지
-//             </Link>
-//          </div>
-//       </div>
-//    );
-// }
+interface Prop {
+   type: "login" | "signup";
+}
+
+// 회원가입 & 로그인 페이지 제목 로고 및 링크 (일반 회원)
+export default function MoverTitle({ type }: Prop) {
+   return (
+      <div className="mb-10">
+         <Link href="/mover-search">
+            <figure className="relative mx-auto h-11 w-22 lg:h-13 lg:w-26">
+               <Image src={logo} alt="무빙 로고" fill />
+            </figure>
+         </Link>
+         <div className="lg:mt- mt-4 flex gap-1 lg:gap-2">
+            <p className="text-black-100 text-12-regular lg:text-20-regular">
+               일반 유저라면?
+            </p>
+            <Link
+               href={type === "login" ? "/sign-in/client" : "/sign-up/client"}
+               className="text-primary-blue-300 text-12-semibold lg:text-20-semibold underline"
+            >
+               일반 유저 전용 페이지
+            </Link>
+         </div>
+      </div>
+   );
+}

--- a/src/components/domain/auth/SignInForm.tsx
+++ b/src/components/domain/auth/SignInForm.tsx
@@ -16,7 +16,7 @@ export default function SignInForm({ userType }: Prop) {
    // ✅ 함수 모음
    const { register, errors, isValid, onSubmit, isLoading, handleSubmit } =
       useSignInForm();
-
+      
    return (
       <form
          onSubmit={handleSubmit((data) => onSubmit(userType)(data))}

--- a/src/components/domain/auth/SignUpForm.tsx
+++ b/src/components/domain/auth/SignUpForm.tsx
@@ -7,6 +7,7 @@ import SolidButton from "@/components/common/SolidButton";
 import Link from "next/link";
 import useSignUpForm from "@/lib/hooks/useSignUpForm";
 import { UserType } from "@/lib/types";
+import { SignUpFormValues } from "@/lib/schemas";
 
 interface Prop {
    userType: UserType;
@@ -23,7 +24,7 @@ export default function SignUpForm({ userType }: Prop) {
          onSubmit={handleSubmit((data) => onSubmit(userType)(data))}
          className="flex w-full flex-col gap-4"
       >
-         <AuthInput
+         <AuthInput<SignUpFormValues>
             type="text"
             name="name"
             label="이름"
@@ -31,7 +32,7 @@ export default function SignUpForm({ userType }: Prop) {
             register={register}
             error={errors.name?.message}
          />
-         <AuthInput
+         <AuthInput<SignUpFormValues>
             type="email"
             name="email"
             label="이메일"
@@ -39,7 +40,7 @@ export default function SignUpForm({ userType }: Prop) {
             register={register}
             error={errors.email?.message}
          />
-         <AuthInput
+         <AuthInput<SignUpFormValues>
             type="text"
             name="phone"
             label="전화번호"
@@ -47,14 +48,14 @@ export default function SignUpForm({ userType }: Prop) {
             register={register}
             error={errors.phone?.message}
          />
-         <PasswordInput
+         <PasswordInput<SignUpFormValues>
             name="password"
             label="비밀번호"
             placeholder="비밀번호를 입력해 주세요"
             register={register}
             error={errors.password?.message}
          />
-         <PasswordInput
+         <PasswordInput<SignUpFormValues>
             name="passwordConfirmation"
             label="비밀번호 확인"
             placeholder="비밀번호를 다시 한번 입력해 주세요"

--- a/src/components/domain/dashboard/BasicInfoForms.tsx
+++ b/src/components/domain/dashboard/BasicInfoForms.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React from "react";
+import BasicInputField from "./BasicInputField";
+import SecretInputField from "./SecretInputField";
+import { useRouter } from "next/navigation";
+import useMoverBasicInfo from "@/lib/hooks/useMoverBasicInfo";
+import { MoverBasicInfoInput } from "@/lib/schemas/dashboard.schema";
+import SolidButton from "@/components/common/SolidButton";
+import OutlinedButton from "@/components/common/OutlinedButton";
+
+export default function BasicInfoForms() {
+   const router = useRouter();
+
+   const { register, errors, isValid, isLoading, handleSubmit, onSubmit } =
+      useMoverBasicInfo();
+
+   return (
+      <form onSubmit={handleSubmit(onSubmit)}>
+         <div className="flex flex-col lg:flex-row lg:gap-18">
+            <div className="flex-1">
+               <BasicInputField<MoverBasicInfoInput>
+                  name="name"
+                  text="이름"
+                  placeholder="사이트에 노출될 본명을 입력해주세요"
+                  register={register}
+                  error={errors.name?.message}
+               />
+
+               <hr className="p-o border-line-100 my-8 border-t" />
+
+               <BasicInputField<MoverBasicInfoInput>
+                  name="email"
+                  text="이메일"
+                  placeholder="moving.@email.com"
+                  register={register}
+                  error={errors.email?.message}
+               />
+
+               <hr className="p-o border-line-100 my-8 border-t" />
+
+               <BasicInputField<MoverBasicInfoInput>
+                  name="phone"
+                  text="전화번호"
+                  placeholder="01012345678"
+                  register={register}
+                  error={errors.phone?.message}
+               />
+            </div>
+
+            <hr className="p-o border-line-100 my-8 border-t lg:hidden" />
+
+            <div className="flex-1">
+               <SecretInputField<MoverBasicInfoInput>
+                  name="existedPassword"
+                  text="현재 비밀번호"
+                  placeholder="현재 비밀번호를 입력해주세요"
+                  register={register}
+                  error={errors.existedPassword?.message}
+               />
+
+               <hr className="p-o border-line-100 my-8 border-t" />
+
+               <SecretInputField<MoverBasicInfoInput>
+                  name="newPassword"
+                  text="새 비밀번호"
+                  placeholder="새 비밀번호를 입력해주세요"
+                  register={register}
+                  error={errors.newPassword?.message}
+               />
+
+               <hr className="p-o border-line-100 my-8 border-t" />
+
+               <SecretInputField<MoverBasicInfoInput>
+                  name="newPasswordConfirmation"
+                  text="새 비밀번호 확인"
+                  placeholder="새 비밀번호를 다시 한번 입력해주세요"
+                  register={register}
+                  error={errors.newPasswordConfirmation?.message}
+               />
+
+               <hr className="p-o border-line-100 my-8 border-t lg:hidden" />
+            </div>
+         </div>
+
+         <div className="flex flex-col gap-2 lg:mt-16 lg:flex-row-reverse lg:gap-8">
+            <SolidButton disabled={!isValid || isLoading} type="submit">
+               {isLoading ? "수정 중..." : "수정하기"}
+            </SolidButton>
+            <OutlinedButton onClick={() => router.push("/dashboard")}>
+               취소
+            </OutlinedButton>
+         </div>
+      </form>
+   );
+}

--- a/src/components/domain/dashboard/BasicInputField.tsx
+++ b/src/components/domain/dashboard/BasicInputField.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { BasicInfoInputProps } from "@/lib/types";
+import React from "react";
+import { FieldValues } from "react-hook-form";
+import ErrorText from "../auth/ErrorText";
+
+//기본정보 수정페이지 기본input 컴포넌트화
+function BasicInputField<T extends FieldValues>({
+   name,
+   text,
+   placeholder,
+   register,
+   error,
+}: BasicInfoInputProps<T>) {
+   return (
+      <div className="flex flex-col gap-4 leading-8">
+         <div className="text-16-semibold lg:text-20-semibold">{text}</div>
+         <input
+            {...register(name)}
+            name={name}
+            type="text"
+            placeholder={placeholder}
+            className={`mg:h-13 bg-bg-200 h-13 w-full rounded-2xl pl-3.5 placeholder:text-gray-300 lg:h-16 ${error ? "border border-red-500" : ""}`}
+         />
+
+         {error && <ErrorText error={error} />}
+      </div>
+   );
+}
+
+export default BasicInputField;

--- a/src/components/domain/dashboard/SecretInputField.tsx
+++ b/src/components/domain/dashboard/SecretInputField.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import visibilityOff from "@/assets/images/visibilityOffIcon.svg";
+import visibilityOn from "@/assets/images/visibilityIcon.svg";
+import { FieldValues } from "react-hook-form";
+import { BasicInfoInputProps } from "@/lib/types";
+import ErrorText from "../auth/ErrorText";
+
+//기본정보 수정페이지 비밀번호input 컴포넌트화
+function SecretInputField<T extends FieldValues>({
+   name,
+   text,
+   placeholder,
+   register,
+   error,
+}: BasicInfoInputProps<T>) {
+   const [isVisible, setIsVisible] = useState(false);
+
+   const toggleEyeIcon = () => setIsVisible((prev) => !prev);
+
+   return (
+      <div className="relative flex flex-col gap-4 leading-8">
+         <div className="text-16-semibold lg:text-20-semibold">{text}</div>
+         <input
+            type={isVisible ? "text" : "password"}
+            placeholder={placeholder}
+            {...register(name)}
+            name={name}
+            className={`bg-bg-200 mg:h-13 h-13 w-full rounded-2xl pl-3.5 placeholder:text-gray-300 lg:h-16 ${error ? "border border-red-500" : ""}`}
+         />
+         <Image
+            className="absolute lg:top-16.5 lg:right-3"
+            src={isVisible ? visibilityOn : visibilityOff}
+            alt={isVisible ? "비밀번호 보기" : "비밀번호 숨김"}
+            onClick={toggleEyeIcon}
+         />
+
+         {error && <ErrorText error={error} />}
+      </div>
+   );
+}
+
+export default SecretInputField;

--- a/src/components/domain/profile/ButtonInputField.tsx
+++ b/src/components/domain/profile/ButtonInputField.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import React from "react";
+import { FieldValue, InputFieldProps } from "@/lib/types/profile.types";
+import { regions } from "@/constants";
+import { Controller, Path } from "react-hook-form";
+import ErrorText from "../auth/ErrorText";
+
+//주석: serviceType인지 Area인지 boolean으로 분기처리
+function ButtonInputField<T extends Record<string, FieldValue>>({
+   name,
+   text,
+   control,
+   isServiceType,
+   isArea,
+   error,
+}: InputFieldProps<T>) {
+   const serviceTypes = ["소형이사", "가정이사", "사무실이사"];
+   const areaOptions = regions;
+
+   const options = isServiceType ? serviceTypes : isArea ? areaOptions : [];
+
+   return (
+      <div className="text-16-semibold lg:text-20-semibold flex flex-col gap-6 leading-8">
+         <div>
+            {text}
+            <span className="text-blue-300"> *</span>
+            {error && <ErrorText error={error.message} />}
+         </div>
+
+         <Controller<T, Path<T>>
+            name={name}
+            control={control}
+            render={({ field }) => {
+               const selectedValues = (field.value as string[]) || [];
+
+               const toggleOption = (option: string) => {
+                  const updated = selectedValues.includes(option)
+                     ? selectedValues.filter((item) => item !== option)
+                     : [...selectedValues, option];
+
+                  field.onChange(updated);
+               };
+
+               return (
+                  <div
+                     className={
+                        isArea
+                           ? "grid w-[90%] grid-cols-5 gap-x-2 gap-y-3 lg:gap-x-3.5 lg:gap-y-4.5"
+                           : "flex gap-3"
+                     }
+                  >
+                     {options.map((option) => {
+                        const isSelected = selectedValues.includes(option);
+                        return (
+                           <button
+                              key={option}
+                              type="button"
+                              onClick={() => toggleOption(option)}
+                              className={`text-14-medium flex justify-center rounded-full border px-3 py-2.5 leading-6.5 transition ${
+                                 isSelected
+                                    ? "border-primary-blue-300 text-primary-blue-300 bg-primary-blue-50"
+                                    : "bg-bg-200 border-gray-100 text-gray-700"
+                              } ${isArea ? "lg:px-5" : "px-5"}`}
+                           >
+                              {option}
+                           </button>
+                        );
+                     })}
+                  </div>
+               );
+            }}
+         />
+      </div>
+   );
+}
+
+export default ButtonInputField;

--- a/src/components/domain/profile/ButtonInputField.tsx
+++ b/src/components/domain/profile/ButtonInputField.tsx
@@ -20,6 +20,8 @@ function ButtonInputField<T extends Record<string, FieldValue>>({
 
    const options = isServiceType ? serviceTypes : isArea ? areaOptions : [];
 
+   if (!control) return null;
+
    return (
       <div className="text-16-semibold lg:text-20-semibold flex flex-col gap-6 leading-8">
          <div>

--- a/src/components/domain/profile/GeneralInputField.tsx
+++ b/src/components/domain/profile/GeneralInputField.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { FieldValue, InputFieldProps } from "@/lib/types/profile.types";
+import ErrorText from "../auth/ErrorText";
+
+//일반적인 (별명, 경력, 한 줄 소개) input인 경우
+function GeneralInputField<T extends Record<string, FieldValue>>({
+   name,
+   text,
+   placeholder,
+   register,
+   error,
+}: InputFieldProps<T>) {
+   return (
+      <div className="flex flex-col gap-4 leading-8">
+         <div className="text-16-semibold lg:text-20-semibold">
+            {text}
+            <span className="text-blue-300"> *</span>
+         </div>
+         <input
+            type="text"
+            {...register?.(name)}
+            className={`mg:h-13 bg-bg-200 h-13 w-full rounded-2xl pl-3.5 placeholder:text-gray-300 lg:h-16 ${error ? "border border-red-500" : ""}`}
+            placeholder={placeholder}
+         />
+
+         {error && <ErrorText error={error.message} />}
+      </div>
+   );
+}
+
+export default GeneralInputField;

--- a/src/components/domain/profile/ImageInputField.tsx
+++ b/src/components/domain/profile/ImageInputField.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { FieldValue, InputFieldProps } from "@/lib/types";
+import React from "react";
+import { Controller } from "react-hook-form";
+
+//프로필 이미지 input인 경우
+function ImageInputField<T extends Record<string, FieldValue>>({
+   name,
+   text,
+   control,
+}: InputFieldProps<T>) {
+   return (
+      <div className="text-16-semibold lg:text-20-semibold flex flex-col gap-4">
+         <div>{text}</div>
+         <Controller
+            name={name}
+            control={control}
+            render={({ field, fieldState }) => (
+               <>
+                  <input
+                     type="file"
+                     accept="image/*"
+                     onChange={(e) => field.onChange(e.target.files?.[0])}
+                  />
+                  {fieldState.error && (
+                     <p className="text-sm text-red-500">
+                        {fieldState.error.message}
+                     </p>
+                  )}
+               </>
+            )}
+         />
+      </div>
+   );
+}
+
+export default ImageInputField;

--- a/src/components/domain/profile/MoverProfilePostForms.tsx
+++ b/src/components/domain/profile/MoverProfilePostForms.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import useMoverCreateProfile from "@/lib/hooks/useMoverCreateProfile";
+import React from "react";
+import ImageInputField from "./ImageInputField";
+import GeneralInputField from "./GeneralInputField";
+import TextAreaInputField from "./TextAreaInputField";
+import ButtonInputField from "./ButtonInputField";
+import SolidButton from "@/components/common/SolidButton";
+
+function MoverProfilePostForm() {
+   const {
+      register,
+      control,
+      errors,
+      isValid,
+      isLoading,
+      handleSubmit,
+      onSubmit,
+   } = useMoverCreateProfile();
+
+   return (
+      <form
+         onSubmit={handleSubmit(onSubmit)}
+         className="mt-6 flex w-full flex-col lg:mt-12"
+      >
+         <div className="flex flex-col lg:flex-row lg:gap-18">
+            <div className="flex flex-1 flex-col">
+               <ImageInputField
+                  name="image"
+                  text="프로필 이미지"
+                  control={control}
+                  error={errors.image}
+               />
+
+               <hr className="border-line-100 m-0 my-8 hidden border-t p-0 lg:block" />
+
+               <div className="mt-8">
+                  <GeneralInputField
+                     name="nickName"
+                     text="별명"
+                     placeholder="사이트에 노출될 이름을 입력해주세요"
+                     register={register}
+                     error={errors.nickName}
+                  />
+               </div>
+
+               <hr className="border-line-100 m-0 my-8 border-t p-0" />
+
+               <GeneralInputField
+                  name="career"
+                  text="경력"
+                  placeholder="기사님의 경력을 입력해주세요"
+                  register={register}
+                  error={errors.career}
+               />
+
+               <hr className="border-line-100 m-0 my-8 border-t p-0" />
+
+               <GeneralInputField
+                  name="onelineIntroduction"
+                  text="한 줄 소개"
+                  placeholder="한 줄 소개를 입력해주세요"
+                  register={register}
+                  error={errors.onelineIntroduction}
+               />
+
+               <hr className="border-line-100 m-0 my-8 border-t p-0 lg:hidden" />
+            </div>
+
+            <div className="flex-1">
+               <TextAreaInputField
+                  name="detailDescription"
+                  text="상세 설명"
+                  placeholder="상세 내용을 입력해주세요"
+                  register={register}
+                  error={errors.detailDescription}
+               />
+
+               <hr className="border-line-100 m-0 my-8 border-t p-0" />
+
+               <ButtonInputField
+                  name="serviceType"
+                  text="제공 서비스"
+                  isServiceType={true}
+                  error={
+                     Array.isArray(errors.serviceType)
+                        ? errors.serviceType[0]
+                        : errors.serviceType
+                  }
+               />
+
+               <hr className="border-line-100 m-0 my-8 border-t p-0" />
+
+               <ButtonInputField
+                  name="area"
+                  text="서비스 가능 지역"
+                  isArea={true}
+                  control={control}
+                  error={
+                     Array.isArray(errors.area) ? errors.area[0] : errors.area
+                  }
+               />
+            </div>
+         </div>
+
+         <div className="mt-17 lg:pl-185">
+            <SolidButton disabled={!isValid || isLoading} type="submit">
+               {isLoading ? "등록 중..." : "시작하기"}
+            </SolidButton>
+         </div>
+      </form>
+   );
+}
+
+export default MoverProfilePostForm;

--- a/src/components/domain/profile/TextAreaInputField.tsx
+++ b/src/components/domain/profile/TextAreaInputField.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import { FieldValue, InputFieldProps } from "@/lib/types/profile.types";
+import ErrorText from "../auth/ErrorText";
+
+//상세 설명 (textArea) input인 경우
+function TextAreaInputField<T extends Record<string, FieldValue>>({
+   name,
+   text,
+   placeholder,
+   register,
+   error,
+}: InputFieldProps<T>) {
+   return (
+      <div className="flex flex-col gap-4">
+         <div className="text-16-semibold lg:text-20-semibold">
+            {text}
+            <span className="text-blue-300"> *</span>
+         </div>
+         <textarea
+            {...register?.(name)}
+            className={`mg:h-13 bg-bg-200 h-13 w-full rounded-2xl pt-3.5 pl-3.5 placeholder:text-gray-300 lg:h-40 ${error ? "border border-red-500" : ""}`}
+            placeholder={placeholder}
+         />
+
+         {error && <ErrorText error={error.message} />}
+      </div>
+   );
+}
+
+export default TextAreaInputField;

--- a/src/lib/api/auth/requests/createProfile.ts
+++ b/src/lib/api/auth/requests/createProfile.ts
@@ -1,0 +1,16 @@
+import { MoverProfileRequestInput } from "@/lib/schemas/profile.schema";
+import { tokenFetch } from "@/lib/utils";
+
+//기사님 기본정보 수정 api
+async function createProfile(data: MoverProfileRequestInput) {
+   const url = "/profile/mover";
+   return await tokenFetch(url, {
+      method: "POST",
+      headers: {
+         "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+   });
+}
+
+export default createProfile;

--- a/src/lib/api/auth/requests/updateInfo.ts
+++ b/src/lib/api/auth/requests/updateInfo.ts
@@ -1,0 +1,16 @@
+import { MoverBasicInfoInput } from "@/lib/schemas/dashboard.schema";
+import { tokenFetch } from "@/lib/utils";
+
+//기사님 기본정보 수정 api
+async function updateInfo(data: MoverBasicInfoInput) {
+   const url = "/dashboard/edit/mover";
+   return await tokenFetch(url, {
+      method: "PATCH",
+      headers: {
+         "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+   });
+}
+
+export default updateInfo;

--- a/src/lib/hooks/useMoverBasicInfo.ts
+++ b/src/lib/hooks/useMoverBasicInfo.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useAuth } from "@/context/AuthContext";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { AuthFetchError } from "../types";
+import {
+   MoverBasicInfoInput,
+   MoverBasicInfoSchema,
+} from "../schemas/dashboard.schema";
+import updateInfo from "../api/auth/requests/updateInfo";
+
+function useMoverBasicInfo() {
+   const { user } = useAuth();
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
+
+   const {
+      register,
+      handleSubmit,
+      formState: { errors, isValid },
+      setError,
+   } = useForm<MoverBasicInfoInput>({
+      resolver: zodResolver(MoverBasicInfoSchema),
+      mode: "onChange",
+      defaultValues: {
+         name: user?.name || "",
+         email: user?.email || "",
+         phone: user?.phone || "",
+         existedPassword: "",
+         newPassword: "",
+         newPasswordConfirmation: "",
+      },
+   });
+
+   const onSubmit = async (data: MoverBasicInfoInput) => {
+      setIsLoading(true);
+
+      try {
+         const res = await updateInfo(data);
+
+         if (res.data.accessToken && res.data.user) {
+            router.push("/dashboard"); //TODO: 수정사항 repatch
+         }
+      } catch (error) {
+         console.error("기사님 기본정보 수정 실패:", error);
+
+         const customError = error as AuthFetchError;
+
+         if (customError?.status && customError.body?.data) {
+            Object.entries(customError.body.data).forEach(([key, message]) => {
+               setError(key as keyof MoverBasicInfoInput, {
+                  type: "server",
+                  message: String(message),
+               });
+            });
+         } else {
+            console.error("예상치 못한 에러: ", customError?.body?.message);
+         }
+      } finally {
+         setIsLoading(false);
+      }
+   };
+   return { register, errors, isValid, isLoading, handleSubmit, onSubmit };
+}
+
+export default useMoverBasicInfo;

--- a/src/lib/hooks/useMoverCreateProfile.ts
+++ b/src/lib/hooks/useMoverCreateProfile.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AuthFetchError } from "../types";
+import {
+   MoverProfileInput,
+   MoverProfileSchema,
+} from "../schemas/profile.schema";
+import createProfile from "../api/auth/requests/createProfile";
+
+function useMoverCreateProfile() {
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
+
+   const {
+      register,
+      handleSubmit,
+      setError,
+      control,
+      formState: { errors, isValid },
+      setValue,
+      watch,
+   } = useForm<MoverProfileInput>({
+      resolver: zodResolver(MoverProfileSchema),
+      mode: "onChange",
+   });
+
+   const onSubmit = async (data: MoverProfileInput) => {
+      setIsLoading(true);
+
+      const processedData = {
+         ...data,
+         career: Number(data.career), // string > number로 변환
+      };
+
+      try {
+         const res = await createProfile(processedData);
+
+         //디버깅
+         console.log("러후니ㅏ!!!프로필 등록 응답 확인", res);
+
+         if (res.data.user) {
+            router.push("/dashboard"); //TODO: 마이페이지로 이동하도록
+         }
+      } catch (error) {
+         console.error("기사님 프로필 등록 실패: ", error);
+
+         const customError = error as AuthFetchError;
+
+         if (customError?.status) {
+            Object.entries(customError.body.data!).forEach(([key, message]) => {
+               setError(key as keyof MoverProfileInput, {
+                  type: "server",
+                  message: String(message),
+               });
+            });
+         } else {
+            console.error("예상치 못한 에러: ", customError?.body.message);
+         }
+      } finally {
+         setIsLoading(false);
+      }
+   };
+
+   return {
+      register,
+      errors,
+      control,
+      setValue,
+      watch,
+      isValid,
+      isLoading,
+      handleSubmit,
+      onSubmit,
+   };
+}
+
+export default useMoverCreateProfile;

--- a/src/lib/hooks/useMoverCreateProfile.ts
+++ b/src/lib/hooks/useMoverCreateProfile.ts
@@ -39,11 +39,8 @@ function useMoverCreateProfile() {
       try {
          const res = await createProfile(processedData);
 
-         //디버깅
-         console.log("러후니ㅏ!!!프로필 등록 응답 확인", res);
-
          if (res.data.user) {
-            router.push("/dashboard"); //TODO: 마이페이지로 이동하도록
+            router.push("/dashboard"); //TODO: 마이페이지로 이동하는지 확인
          }
       } catch (error) {
          console.error("기사님 프로필 등록 실패: ", error);

--- a/src/lib/hooks/useSignInForm.ts
+++ b/src/lib/hooks/useSignInForm.ts
@@ -41,7 +41,7 @@ export default function useSignInForm() {
             router.replace("/mover-search");
          }
       } catch (error) {
-         console.error("일반 로그인 실패: ", error);
+         console.error("로그인 실패: ", error);
 
          // 오류 처리: 메시지로
          const customError = error as AuthFetchError;

--- a/src/lib/hooks/useSignInForm.ts
+++ b/src/lib/hooks/useSignInForm.ts
@@ -21,7 +21,7 @@ export default function useSignInForm() {
       handleSubmit,
       setError,
       formState: { errors, isValid },
-   } = useForm({
+   } = useForm<SignInFormValues>({
       mode: "onChange",
       resolver: zodResolver(SignInFormSchema),
    });

--- a/src/lib/schemas/dashboard.schema.ts
+++ b/src/lib/schemas/dashboard.schema.ts
@@ -1,1 +1,26 @@
 // 도메인 단위
+
+import z from "zod";
+
+//기사님 기본정보 수정 시 사용
+const rawMoverBasicInfoSchema = {
+   name: z.string().min(2, "본명을 입력해주세요"),
+   email: z.string().email("올바른 이메일 형식이 아닙니다."),
+   phone: z
+      .string()
+      .min(10, "최소 10자리 이상이어야 합니다.")
+      .regex(/^\d+$/, "숫자만 입력해주세요."),
+   existedPassword: z.string().min(8, "기존 비밀번호를 입력해주세요."),
+   newPassword: z.string().min(8, "최소 8자리 이상이어야 합니다."),
+   newPasswordConfirmation: z.string().min(8, "최소 8자리 이상이어야 합니다."),
+};
+
+//refine 로직 때문에 분리 (cheackNewPassword)
+export const MoverBasicInfoSchema = z
+   .object(rawMoverBasicInfoSchema)
+   .refine((data) => data.newPassword === data.newPasswordConfirmation, {
+      path: ["newPasswordConfirmation"],
+      message: "비밀번호가 일치하지 않습니다.",
+   });
+
+export type MoverBasicInfoInput = z.infer<typeof MoverBasicInfoSchema>;

--- a/src/lib/schemas/profile.schema.ts
+++ b/src/lib/schemas/profile.schema.ts
@@ -1,1 +1,35 @@
 // 도메인 단위
+
+import z from "zod";
+
+//기사님 프로필 등록 시 사용 (career가 string)
+export const MoverProfileSchema = z.object({
+   image: z.string().optional(),
+   nickName: z.string().min(1, "별명을 입력해주세요."),
+   career: z
+      .string()
+      .min(1, "숫자만 입력해주세요.") // 빈 문자열인지 체크 (처음부터 숫자로 하면 빈문자열을 0으로 인식함)
+      .refine((val) => !isNaN(Number(val)) && Number(val) >= 0, {
+         message: "경력은 0 이상이어야 합니다.",
+      }),
+   onelineIntroduction: z.string().min(8, "8자 이상 입력해주세요."),
+   detailDescription: z.string().min(10, "10자 이상 입력해주세요."),
+   serviceType: z.array(z.string().min(1)).min(1, "* 1개 이상 선택해주세요."),
+   area: z.array(z.string().min(1)).min(1, "* 1개 이상 선택해주세요."),
+});
+
+// 기사님 프로필 등록 API 전송용 타입 (career가 number)
+export const MoverProfileRequestSchema = z.object({
+   image: z.string().optional(),
+   nickName: z.string(),
+   career: z.number().min(0, "경력은 0 이상이어야 합니다."),
+   onelineIntroduction: z.string(),
+   detailDescription: z.string(),
+   serviceType: z.array(z.string()),
+   area: z.array(z.string()),
+});
+
+export type MoverProfileRequestInput = z.infer<
+   typeof MoverProfileRequestSchema
+>;
+export type MoverProfileInput = z.infer<typeof MoverProfileSchema>;

--- a/src/lib/types/auth.types.ts
+++ b/src/lib/types/auth.types.ts
@@ -72,7 +72,7 @@ export interface AuthFetchError {
    };
 }
 
-//TODO: 기사님 기본정보 수정 시 사용
+//기사님 기본정보 수정 시 사용 //TODO:기본정보 타입 정리할 것
 export interface BasicInfoInputProps<T extends FieldValues> {
    name: Path<T>;
    text: string;

--- a/src/lib/types/auth.types.ts
+++ b/src/lib/types/auth.types.ts
@@ -1,10 +1,4 @@
-import {
-   Control,
-   FieldError,
-   FieldValues,
-   Path,
-   UseFormRegister,
-} from "react-hook-form";
+import { FieldValues, Path, UseFormRegister } from "react-hook-form";
 
 // ✅ userType
 export type UserType = "client" | "mover";

--- a/src/lib/types/auth.types.ts
+++ b/src/lib/types/auth.types.ts
@@ -1,4 +1,10 @@
-import { FieldValues, Path, UseFormRegister } from "react-hook-form";
+import {
+   Control,
+   FieldError,
+   FieldValues,
+   Path,
+   UseFormRegister,
+} from "react-hook-form";
 
 // ✅ userType
 export type UserType = "client" | "mover";
@@ -70,4 +76,13 @@ export interface AuthFetchError {
          [key: string]: string | undefined;
       };
    };
+}
+
+//TODO: 기사님 기본정보 수정 시 사용
+export interface BasicInfoInputProps<T extends FieldValues> {
+   name: Path<T>;
+   text: string;
+   placeholder: string;
+   register: UseFormRegister<T>;
+   error?: string;
 }

--- a/src/lib/types/profile.types.ts
+++ b/src/lib/types/profile.types.ts
@@ -1,17 +1,22 @@
+import { Control, FieldError, Path, UseFormRegister } from "react-hook-form";
 import { User } from "./auth.types";
 
+//바로 아래+기사님 프로필 컴포넌트에서 사용
+export type FieldValue = string | string[] | undefined;
+
 //기사님 프로필 컴포넌트 모음집
-export interface InputFieldProps {
-   name: string; //useActionsState로 매핑하기 위한
+export interface InputFieldProps<T extends Record<string, FieldValue>> {
+   name: Path<T>;
    text: string;
    placeholder?: string;
 
    isServiceType?: boolean; //제공 서비스인지
    isArea?: boolean; //서비스 가능 지역인지
+   options?: string[];
 
-   defaultValue?: string | string[];
-   onValidChange?: (name: string, value: boolean) => void;
-   validator?: (value: string | string[]) => ValidationResult; // 유효성 검사 함수
+   control?: Control<T>;
+   register?: UseFormRegister<T>;
+   error?: FieldError;
 }
 
 //기사님 프로필 유효성 함수 관련

--- a/src/lib/utils/fetch-client.ts
+++ b/src/lib/utils/fetch-client.ts
@@ -11,8 +11,7 @@ import isFetchError from "../utils/fetch-error.util";
 
 // ✅ 기본 url : 환경 변수 설정해서 쓰세요.
 export const BASE_URL =
-   process.env.NEXT_PUBLIC_API_URL ||
-   "https://sixth-moving-4team-be.onrender.com"; // "http://localhost:4000";
+   process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 // ✅ 서버에서 던진 오류 받기: 문자 형태, 객체 형태(data로 받음)
 async function handleResponse(response: Response) {


### PR DESCRIPTION
## 작업 개요
- 기사님 회원가입 & 로그인 폴더 구조 적용

---

## 작업 상세 내용
- [x] 기사님 회원가입 & 로그인 폴더 구조 적용
- [x] react-hook-form 사용하여 리펙터링
---

## 🗂️ 수정한 파일

---

## 🗂️ 새로 작성한 파일
- `src/components/domain/dashboard/BasicInfoForms.tsx`
- `src/components/domain/dashboard/BasicInputField.tsx`
- `src/components/domain/dashboard/SecretInputField.tsx`
- `src/components/domain/profile/ButtonInputField.tsx`
- `src/components/domain/profile/GeneralInputField.tsx`
- `src/components/domain/profile/ImageInputField.tsx`
- `src/components/domain/profile/MoverProfilePostForms.tsx`
- `src/components/domain/profile/TextAreaInputField.tsx`
- `src/lib/api/auth/requests/createProfile.ts`
- `src/lib/api/auth/requests/updateInfo.ts`
- `src/lib/hooks/useMoverBasicInfo.ts`
- `src/lib/hooks/useMoverCreateProfile.ts`

---

## 기타 참고 사항
- 기본정보수정, 프로필 관련은 추후 수정 예정 (인증인가부터 함)
