### PR TITLE
fefactor: 기사님 기본정보 수정 API 연동

### DIFF
--- a/src/lib/api/auth/requests/updateInfo.ts
+++ b/src/lib/api/auth/requests/updateInfo.ts
@@ -2,7 +2,7 @@ import { MoverBasicInfoInput } from "@/lib/schemas/dashboard.schema";
 import { tokenFetch } from "@/lib/utils";
 
 //기사님 기본정보 수정 api
-async function updateInfo(data: MoverBasicInfoInput) {
+export default async function updateInfo(data: MoverBasicInfoInput) {
    const url = "/dashboard/edit/mover";
    return await tokenFetch(url, {
       method: "PATCH",
@@ -12,5 +12,3 @@ async function updateInfo(data: MoverBasicInfoInput) {
       body: JSON.stringify(data),
    });
 }
-
-export default updateInfo;

--- a/src/lib/hooks/useMoverBasicInfo.ts
+++ b/src/lib/hooks/useMoverBasicInfo.ts
@@ -2,7 +2,7 @@
 
 import { useAuth } from "@/context/AuthContext";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { AuthFetchError } from "../types";
@@ -11,9 +11,10 @@ import {
    MoverBasicInfoSchema,
 } from "../schemas/dashboard.schema";
 import updateInfo from "../api/auth/requests/updateInfo";
+import { tokenSettings } from "../utils";
 
 function useMoverBasicInfo() {
-   const { user } = useAuth();
+   const { user, refreshUser } = useAuth();
    const router = useRouter();
    const [isLoading, setIsLoading] = useState(false);
 
@@ -22,6 +23,7 @@ function useMoverBasicInfo() {
       handleSubmit,
       formState: { errors, isValid },
       setError,
+      reset,
    } = useForm<MoverBasicInfoInput>({
       resolver: zodResolver(MoverBasicInfoSchema),
       mode: "onChange",
@@ -35,14 +37,30 @@ function useMoverBasicInfo() {
       },
    });
 
+   //user 정보가 비동기적으로 들어오기 때문에
+   useEffect(() => {
+      if (user) {
+         reset({
+            name: user.name ?? "",
+            email: user.email ?? "",
+            phone: user.phone ?? "",
+            existedPassword: "",
+            newPassword: "",
+            newPasswordConfirmation: "",
+         });
+      }
+   }, [user, reset]);
+
    const onSubmit = async (data: MoverBasicInfoInput) => {
       setIsLoading(true);
 
       try {
          const res = await updateInfo(data);
 
-         if (res.data.accessToken && res.data.user) {
-            router.push("/dashboard"); //TODO: 수정사항 repatch
+         refreshUser();
+
+         if (res) {
+            router.push("/dashboard");
          }
       } catch (error) {
          console.error("기사님 기본정보 수정 실패:", error);

--- a/src/lib/hooks/useMoverBasicInfo.ts
+++ b/src/lib/hooks/useMoverBasicInfo.ts
@@ -11,7 +11,6 @@ import {
    MoverBasicInfoSchema,
 } from "../schemas/dashboard.schema";
 import updateInfo from "../api/auth/requests/updateInfo";
-import { tokenSettings } from "../utils";
 
 function useMoverBasicInfo() {
    const { user, refreshUser } = useAuth();

--- a/src/lib/hooks/useMoverBasicInfo.ts
+++ b/src/lib/hooks/useMoverBasicInfo.ts
@@ -55,7 +55,23 @@ function useMoverBasicInfo() {
       setIsLoading(true);
 
       try {
-         const res = await updateInfo(data);
+         // 기본정보 수정
+         const payload = {
+            name: data.name,
+            email: data.email,
+            phone: data.phone,
+            existedPassword: data.existedPassword,
+         };
+
+         // 비밀번호도 수정
+         if (data.newPassword && data.newPasswordConfirmation) {
+            Object.assign(payload, {
+               newPassword: data.newPassword,
+               newPasswordConfirmation: data.newPasswordConfirmation,
+            });
+         }
+
+         const res = await updateInfo(payload);
 
          refreshUser();
 

--- a/src/lib/schemas/dashboard.schema.ts
+++ b/src/lib/schemas/dashboard.schema.ts
@@ -11,16 +11,48 @@ const rawMoverBasicInfoSchema = {
       .min(10, "최소 10자리 이상이어야 합니다.")
       .regex(/^\d+$/, "숫자만 입력해주세요."),
    existedPassword: z.string().min(8, "기존 비밀번호를 입력해주세요."),
-   newPassword: z.string().min(8, "최소 8자리 이상이어야 합니다."),
-   newPasswordConfirmation: z.string().min(8, "최소 8자리 이상이어야 합니다."),
+   newPassword: z.string().optional(),
+   newPasswordConfirmation: z.string().optional(),
 };
 
 //refine 로직 때문에 분리 (cheackNewPassword)
 export const MoverBasicInfoSchema = z
    .object(rawMoverBasicInfoSchema)
-   .refine((data) => data.newPassword === data.newPasswordConfirmation, {
-      path: ["newPasswordConfirmation"],
-      message: "비밀번호가 일치하지 않습니다.",
+   .superRefine((data, ctx) => {
+      const { newPassword, newPasswordConfirmation } = data;
+
+      const eitherPasswordExists = !!newPassword || !!newPasswordConfirmation;
+
+      if (eitherPasswordExists) {
+         if (!newPassword || newPassword.length < 8) {
+            ctx.addIssue({
+               // 에러를 특정 필드에 추가
+               path: ["newPassword"],
+               message: "새 비밀번호는 최소 8자리 이상이어야 합니다.",
+               code: z.ZodIssueCode.custom,
+            });
+         }
+
+         if (!newPasswordConfirmation || newPasswordConfirmation.length < 8) {
+            ctx.addIssue({
+               path: ["newPasswordConfirmation"],
+               message: "새 비밀번호 확인은 최소 8자리 이상이어야 합니다.",
+               code: z.ZodIssueCode.custom,
+            });
+         }
+
+         if (
+            newPassword &&
+            newPasswordConfirmation &&
+            newPassword !== newPasswordConfirmation
+         ) {
+            ctx.addIssue({
+               path: ["newPasswordConfirmation"],
+               message: "비밀번호가 일치하지 않습니다.",
+               code: z.ZodIssueCode.custom,
+            });
+         }
+      }
    });
 
 export type MoverBasicInfoInput = z.infer<typeof MoverBasicInfoSchema>;


### PR DESCRIPTION
## 작업 개요
- 기사님 기본정보 수정 데이터 연동

---

## 작업 상세 내용
- [x] 기본정보 수정 후 마이페이지로 이동 확인 (수정된 정보로 반영됨)
- [x] 비밀번호를 재설정하지 않고도 기본정보 수정 가능 (현재 비밀번호 입력은 필수임)

---

## 🗂️ 수정한 파일
- src/components/domain/dashboard/BasicForm.tsx
- src/lib/hooks/useMoverBasicInfo.ts
- src/lib/auth/request/updateInfo.ts
- src/lib/schemas/dashboard.schema.ts

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항

