### PR TITLE
fix: 알림 모달 z-index 조정 및 경로 비교 함수 수정

### DIFF
--- a/src/components/common/NotificationModal.tsx
+++ b/src/components/common/NotificationModal.tsx
@@ -77,7 +77,7 @@ export default function NotificationModal({
    }, [setHasUnread]);
 
    return (
-      <div className="border-line-200 absolute top-10 -left-6 z-100 flex h-80 w-78 -translate-x-1/2 flex-col rounded-3xl border bg-white px-4 py-2.5 shadow-[2px_2px_16px_0px_rgba(0,0,0,0.06)] md:-left-8 lg:top-12 lg:-left-4 lg:h-88 lg:w-90">
+      <div className="border-line-200 absolute top-10 -left-6 z-10 flex h-80 w-78 -translate-x-1/2 flex-col rounded-3xl border bg-white px-4 py-2.5 md:-left-8 lg:top-12 lg:-left-4 lg:h-88 lg:w-90">
          <div className="flex items-center justify-between py-3.5 pr-3 pl-4 md:-left-8 lg:top-12 lg:pl-6">
             <span className="font-bold lg:text-lg">알림</span>
             <button type="button" onClick={() => setIsNotiModalOpen(false)}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({ children }: { children?: React.ReactNode }) {
    const profileRef = useRef<HTMLDivElement>(null);
    const notificationRef = useRef<HTMLDivElement>(null);
 
-   const isActive = (path: string) => pathname.startsWith(path);
+   const isActive = (path: string) => pathnameWithoutLocale.startsWith(path);
    const linkClass = (path: string) =>
       clsx(isActive(path) && "!text-black-400");
 


### PR DESCRIPTION
## 작업 개요
- 알림 모달이 다른 요소보다 위에 떠 있지 않는 문제 해결 및 pathname 비교 함수 수정

---

## 작업 상세 내용
- [x] 알림 모달 z-index를 z-100 → z-10으로 조정
- [x] Header.tsx 내 경로 활성화 비교 함수에서 locale 포함된 pathname → pathnameWithoutLocale로 수정


---

## 🗂️ 수정한 파일
- `src/components/common/NotificationModal.tsx`
- `src/components/layout/Header.tsx`

---



## 기타 참고 사항
- 모달 z-index는 다른 UI와의 겹침 관계를 고려해 조정
- 라우터 경로 비교 시 locale이 포함되어 잘못된 active 상태가 적용되는 문제 해결
