### PR TITLE
fix: 프로필 등록 라우팅 가드 오류 해결

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,11 +49,7 @@ export async function middleware(req: NextRequest) {
    const { isProfileCompleted, userType } = decoded;
 
    // 프로필 등록 미완료 시 다른 페이지 접근 불가
-   if (
-      !isProfileCompleted &&
-      path !== PROFILE_CREATE_PATH &&
-      !path.startsWith(PROFILE_CREATE_PATH + "/")
-   ) {
+   if (!isProfileCompleted && path !== PROFILE_CREATE_PATH) {
       return NextResponse.redirect(new URL(PROFILE_CREATE_PATH, req.url));
    }
 
@@ -63,7 +59,7 @@ export async function middleware(req: NextRequest) {
    }
 
    // 인증된 사용자가 GuestRoute 접근 시
-   if (isGuestRoute) {
+   if (isProfileCompleted && isGuestRoute) {
       return NextResponse.redirect(new URL("/mover-search", req.url));
    }
 


### PR DESCRIPTION
## 작업 개요
- 프로필 등록 페이지에서 프로필 미등록 시에도 `mover-search` 페이지 접근이 허용되는 오류 해결

---

## 작업 상세 내용
- x

---

## 🗂️ 수정한 파일
- `middleware.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x
