### PR TITLE
fix: 프로필 기능 관련 오류 수정 외

### DIFF
--- a/src/app/[locale]/(with-protected)/profile/edit/page.tsx
+++ b/src/app/[locale]/(with-protected)/profile/edit/page.tsx
@@ -12,7 +12,13 @@ export default function EditProfilePage() {
    if (user?.userType === "client") {
       return (
          <div className="pt-4 pb-10 lg:pt-6">
-            <div className="mx-auto max-w-82 lg:max-w-338">
+            <div
+               className={
+                  user?.provider === "LOCAL"
+                     ? "mx-auto max-w-82 lg:max-w-338"
+                     : "mx-auto max-w-82 lg:max-w-200"
+               }
+            >
                <ClientProfileTitle type="수정" />
                <ClientProfileUpdateForm />
             </div>

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -13,6 +13,9 @@ import ImageInputField from "./ImageInputField";
 import { useAuth } from "@/context/AuthContext";
 import { ClientProfileUpdateValue } from "@/lib/schemas";
 
+const style1 = "lg:mb-14 lg:flex-row lg:justify-between lg:gap-14";
+const borderStyle = "border-line-100 my-5 lg:my-8";
+
 export default function ClientProfileUpdateForm() {
    // ✅ 함수 등 모음
    const { user } = useAuth();
@@ -31,9 +34,15 @@ export default function ClientProfileUpdateForm() {
 
    return (
       <form onSubmit={handleSubmit(onSubmit)}>
-         <div className="flex flex-col lg:mb-14 lg:flex-row lg:justify-baseline lg:gap-14">
+         <div
+            className={
+               user?.provider === "LOCAL"
+                  ? `flex flex-col ${style1}`
+                  : "flex flex-col"
+            }
+         >
             {/* ✅ 입력창 모음 */}
-            <div className="flex-1">
+            <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
                <ProfileInput<ClientProfileUpdateValue>
                   type="text"
                   label="이름"
@@ -42,7 +51,13 @@ export default function ClientProfileUpdateForm() {
                   register={register}
                   error={errors.name?.message}
                />
-               <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+               <hr
+                  className={
+                     user?.provider === "LOCAL"
+                        ? `${borderStyle} lg:w-160`
+                        : `${borderStyle} lg:w-full`
+                  }
+               />
                <ProfileInput<ClientProfileUpdateValue>
                   type="email"
                   label="이메일"
@@ -51,7 +66,13 @@ export default function ClientProfileUpdateForm() {
                   register={register}
                   error={errors.email?.message}
                />
-               <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+               <hr
+                  className={
+                     user?.provider === "LOCAL"
+                        ? `${borderStyle} lg:w-160`
+                        : `${borderStyle} lg:w-full`
+                  }
+               />
                <ProfileInput<ClientProfileUpdateValue>
                   type="text"
                   label="전화번호"
@@ -60,7 +81,13 @@ export default function ClientProfileUpdateForm() {
                   register={register}
                   error={errors.phone?.message}
                />
-               <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+               <hr
+                  className={
+                     user?.provider === "LOCAL"
+                        ? `${borderStyle} lg:w-160`
+                        : `${borderStyle} lg:w-full`
+                  }
+               />
                {user && user.provider === "LOCAL" && (
                   <ProfilePasswordInput<ClientProfileUpdateValue>
                      label="현재 비밀번호"
@@ -100,7 +127,7 @@ export default function ClientProfileUpdateForm() {
                <hr className="border-line-100 my-5 lg:my-8 lg:hidden" />
             )}
 
-            <div className="flex-1">
+            <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
                {/* ✅ 프로필 이미지 */}
                <ImageInputField
                   name="profileImage"
@@ -108,7 +135,13 @@ export default function ClientProfileUpdateForm() {
                   control={control}
                />
 
-               <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+               <hr
+                  className={
+                     user?.provider === "LOCAL"
+                        ? `${borderStyle} lg:w-160`
+                        : `${borderStyle} lg:w-full`
+                  }
+               />
 
                {/* ✅ 이용 서비스 */}
                <section>
@@ -138,7 +171,13 @@ export default function ClientProfileUpdateForm() {
                   })}
                </section>
 
-               <hr className="border-line-100 mb-5 lg:mb-8 lg:w-160" />
+               <hr
+                  className={
+                     user?.provider === "LOCAL"
+                        ? `${borderStyle} lg:w-160`
+                        : `${borderStyle} lg:w-full`
+                  }
+               />
 
                {/* ✅ 내가 사는 지역 */}
                <section className="mb-8 lg:mb-14">
@@ -168,17 +207,31 @@ export default function ClientProfileUpdateForm() {
          </div>
 
          {/* ✅ 제출 버튼 */}
-         <section className="flex w-full flex-col gap-2 lg:flex-row lg:justify-between lg:gap-4">
+         <section
+            className={
+               user?.provider === "LOCAL"
+                  ? "flex w-full flex-col gap-2 lg:flex-row lg:justify-between lg:gap-4"
+                  : "flex w-full flex-col gap-2"
+            }
+         >
             <SolidButton
                type="submit"
                disabled={isLoading || !isValid}
-               className="max-w-165 lg:w-auto lg:flex-1"
+               className={
+                  user?.provider === "LOCAL"
+                     ? "max-w-165 lg:w-auto lg:flex-1"
+                     : ""
+               }
             >
                {isLoading ? "로딩 중..." : "수정하기"}
             </SolidButton>
             <OutlinedButton
                type="reset"
-               className="max-w-165 !border-gray-200 !text-gray-200 lg:w-auto lg:flex-1"
+               className={
+                  user?.provider === "LOCAL"
+                     ? "max-w-165 !border-gray-200 !text-gray-200 lg:w-auto lg:flex-1"
+                     : "!border-gray-200 !text-gray-200"
+               }
             >
                취소
             </OutlinedButton>

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -227,7 +227,7 @@ export default function ClientProfileUpdateForm() {
                {isLoading ? "로딩 중..." : "수정하기"}
             </SolidButton>
             <OutlinedButton
-               type="reset"
+               type="button"
                onClick={handleCancel}
                className={
                   user?.provider === "LOCAL"

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -30,6 +30,7 @@ export default function ClientProfileUpdateForm() {
       handleSubmit,
       watch,
       control,
+      handleCancel,
    } = useClientProfileUpdateForm();
 
    return (
@@ -227,6 +228,7 @@ export default function ClientProfileUpdateForm() {
             </SolidButton>
             <OutlinedButton
                type="reset"
+               onClick={handleCancel}
                className={
                   user?.provider === "LOCAL"
                      ? "max-w-165 !border-gray-200 !text-gray-200 lg:w-auto lg:flex-1"

--- a/src/components/domain/profile/ProfileInput.tsx
+++ b/src/components/domain/profile/ProfileInput.tsx
@@ -5,6 +5,8 @@ import ErrorText from "../auth/ErrorText";
 import { FieldValues } from "react-hook-form";
 import { ClientProfileUpdateData } from "@/lib/types";
 
+const style = "flex w-full flex-col gap-2 lg:gap-4";
+
 // ✅ react-hook-form 적용한 Input
 export default function ProfileInput<T extends FieldValues>({
    type = "text",
@@ -13,9 +15,12 @@ export default function ProfileInput<T extends FieldValues>({
    placeholder,
    register,
    error,
+   social,
 }: ClientProfileUpdateData<T>) {
    return (
-      <section className="flex w-full flex-col gap-2 lg:max-w-160 lg:gap-4">
+      <section
+         className={social ? `${style} lg:max-w-160` : `${style} lg:max-w-full`}
+      >
          <label
             htmlFor={name}
             className="text-black-300 text-16-semibold lg:text-20-semibold"

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -80,7 +80,7 @@ export default function useClientProfilePostForm() {
          const res = await clientProfile.post(payload);
 
          if (res.data.isProfileCompleted === true) {
-            // user 상태 즉각 반영
+            // user 상태 즉각 반영: refreshUser와 alert 순서 바꾸면 안 됨
             refreshUser();
             alert("프로필이 등록되었습니다.");
             router.replace("/mover-search");

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -80,10 +80,9 @@ export default function useClientProfilePostForm() {
          const res = await clientProfile.post(payload);
 
          if (res.data.isProfileCompleted === true) {
-            alert("프로필이 등록되었습니다.");
-
             // user 상태 즉각 반영
             refreshUser();
+            alert("프로필이 등록되었습니다.");
             router.replace("/mover-search");
          }
       } catch (error) {

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -89,7 +89,6 @@ export default function useClientProfileUpdateForm() {
 
    // ✅ 기본값 초기화 설정333 = 이름 등을 보존하려면 현재 값 기준으로 써야 함 (취소 버튼으로 연결)
    const handleCancel = () => {
-      console.log("!!!", initialValues);
       reset({ ...initialValues });
    };
 

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -60,11 +60,6 @@ export default function useClientProfileUpdateForm() {
       resolver: zodResolver(updateClientProfileSchema(user?.provider)),
       defaultValues: initialValues, // 새로고침 해야 나옴 (취소 버튼은 상관x)
    });
-
-   // ✅ 기본값 설정 추가
-   // useEffect(() => {
-   //    reset(initialValues);
-   // }, [initialValues, reset]);
 
    // ✅ 이용 서비스 선택
    const handleServiceToggle = (service: ServiceType) => {

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -20,8 +20,8 @@ export default function useClientProfileUpdateForm() {
    const { user, refreshUser } = useAuth();
    const [isLoading, setIsLoading] = useState(false);
 
-   // ✅ 기본값 설정 추가
-   const initialValues: ClientProfileUpdateValue = useMemo(() => {
+   // ✅ 초깃값 보존 용도 기본값
+   const initialValues = useMemo<ClientProfileUpdateValue>(() => {
       if (user?.userType === "client") {
          const client = user as Client;
 
@@ -58,15 +58,13 @@ export default function useClientProfileUpdateForm() {
    } = useForm<ClientProfileUpdateValue>({
       mode: "onChange",
       resolver: zodResolver(updateClientProfileSchema(user?.provider)),
-      defaultValues: initialValues,
+      defaultValues: initialValues, // 새로고침 해야 나옴 (취소 버튼은 상관x)
    });
 
-   // 기본값 초기화 설정22
-   useEffect(() => {
-      if (user?.userType === "client") {
-         reset(initialValues);
-      }
-   }, [user, reset, initialValues]);
+   // ✅ 기본값 설정 추가
+   // useEffect(() => {
+   //    reset(initialValues);
+   // }, [initialValues, reset]);
 
    // ✅ 이용 서비스 선택
    const handleServiceToggle = (service: ServiceType) => {
@@ -89,9 +87,10 @@ export default function useClientProfileUpdateForm() {
       setValue("livingArea", updated, { shouldValidate: true });
    };
 
-   // 기본값 초기화 설정333
+   // ✅ 기본값 초기화 설정333 = 이름 등을 보존하려면 현재 값 기준으로 써야 함 (취소 버튼으로 연결)
    const handleCancel = () => {
-      reset(initialValues);
+      console.log("!!!", initialValues);
+      reset({ ...initialValues });
    };
 
    // ✅ api 호출하고 프로필 생성 성공하면 mover-search로 이동: 이미지 부분 수정해야 함

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -89,7 +89,7 @@ export default function useClientProfileUpdateForm() {
 
    // ✅ 기본값 초기화 설정333 = 이름 등을 보존하려면 현재 값 기준으로 써야 함 (취소 버튼으로 연결)
    const handleCancel = () => {
-      reset({ ...initialValues });
+      reset(initialValues);
    };
 
    // ✅ api 호출하고 프로필 생성 성공하면 mover-search로 이동: 이미지 부분 수정해야 함

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,6 +20,31 @@ export default function useClientProfileUpdateForm() {
    const { user, refreshUser } = useAuth();
    const [isLoading, setIsLoading] = useState(false);
 
+   // ✅ 기본값 설정 추가
+   const initialValues: ClientProfileUpdateValue = useMemo(() => {
+      if (user?.userType === "client") {
+         const client = user as Client;
+
+         return {
+            name: client.name ?? "",
+            email: client.email ?? "",
+            phone: client.phone ?? "",
+            profileImage: client.profileImage ?? "",
+            serviceType: client.serviceType ?? [],
+            livingArea: client.livingArea ?? [],
+         };
+      }
+
+      return {
+         name: "",
+         email: "",
+         phone: "",
+         profileImage: "",
+         serviceType: [],
+         livingArea: [],
+      };
+   }, [user]);
+
    // ✅ react-hook-form
    const {
       register,
@@ -33,27 +58,15 @@ export default function useClientProfileUpdateForm() {
    } = useForm<ClientProfileUpdateValue>({
       mode: "onChange",
       resolver: zodResolver(updateClientProfileSchema(user?.provider)),
-      defaultValues: {
-         name: user?.name || "",
-         email: user?.email || "",
-         phone: user?.phone || "",
-      },
+      defaultValues: initialValues,
    });
 
-   // ✅ 기본값 설정 추가
+   // 기본값 초기화 설정22
    useEffect(() => {
       if (user?.userType === "client") {
-         const client = user as Client;
-
-         const defaultValues: ClientProfileUpdateValue = {
-            profileImage: client.profileImage ?? "",
-            serviceType: client.serviceType ?? [],
-            livingArea: client.livingArea,
-         };
-
-         reset(defaultValues);
+         reset(initialValues);
       }
-   }, [user, reset]);
+   }, [user, reset, initialValues]);
 
    // ✅ 이용 서비스 선택
    const handleServiceToggle = (service: ServiceType) => {
@@ -74,6 +87,11 @@ export default function useClientProfileUpdateForm() {
          : [...current, region];
 
       setValue("livingArea", updated, { shouldValidate: true });
+   };
+
+   // 기본값 초기화 설정333
+   const handleCancel = () => {
+      reset(initialValues);
    };
 
    // ✅ api 호출하고 프로필 생성 성공하면 mover-search로 이동: 이미지 부분 수정해야 함
@@ -143,5 +161,6 @@ export default function useClientProfileUpdateForm() {
       handleSubmit,
       watch,
       control,
+      handleCancel,
    };
 }

--- a/src/lib/hooks/useSignInForm.ts
+++ b/src/lib/hooks/useSignInForm.ts
@@ -39,9 +39,9 @@ export default function useSignInForm() {
 
          // ★ 프로필 등록 안 했으면 프로필 등록, 아니면 기사님 찾기로 이동
          if (!res.data?.isProfileCompleted) {
-            router.push("/profile/create");
+            router.replace("/profile/create");
          } else {
-            router.push("/mover-search");
+            router.replace("/mover-search");
          }
       } catch (error) {
          console.error("로그인 실패: ", error);

--- a/src/lib/schemas/client.schema.ts
+++ b/src/lib/schemas/client.schema.ts
@@ -93,11 +93,6 @@ export const ClientProfilePostSchema = z.object({
 // ✅ 타입 반출
 export type ClientProfilePostValue = z.infer<typeof ClientProfilePostSchema>;
 
-// const clientProfileUpdateSchema = updateClientProfileSchema();
-// export type ClientProfileUpdateValue = z.infer<
-//    typeof clientProfileUpdateSchema
-// >;
-
 export type ClientProfileUpdateValue = z.infer<
    ReturnType<typeof updateClientProfileSchema>
 >;

--- a/src/lib/types/client.types.ts
+++ b/src/lib/types/client.types.ts
@@ -18,4 +18,5 @@ export interface ClientProfileUpdateData<T extends FieldValues> {
    placeholder: string;
    register: UseFormRegister<T>;
    error?: string;
+   social?: boolean;
 }


### PR DESCRIPTION
## 작업 개요
- 프로필 기능 관련 오류 수정
- 프로필 수정 페이지 스타일 변경

---

## 작업 상세 내용
- [x] 버튼 초기화 시 기본값이 같이 사라지는 현상 수정 (버튼 type reset -> button)
- [x] 프로필 등록 창에서 로그인 창으로 뒤로가기 되는 현상 수정 (router.push -> replace)
- [x] 구글 프로필 등록 시 두 번 등록해야 페이지 넘어가는 현상 수정 (refreshUser -> alert 순서 변경) **배포 사이트에서 확인 필요**
- [x] 프로필 수정 페이지 소셜 로그인 시 스타일 변경

---

## 🗂️ 수정한 파일
- `src/app/[locale]/(with-protected)/profile/edit/page.tsx`
- `src/components/domain/profile/ClientProfileUpdateForm.tsx`
- `src/components/domain/profile/ProfileInput.tsx`
- `src/lib/hooks/useClientProfilePostForm.ts`
- `src/lib/hooks/useClientProfileUpdateForm.ts`
- `src/lib/hooks/useSignInForm.ts`
- `src/lib/types/client.types.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x