### PR TITLE
fix: 배포 환경에서 프로필 등록 순서 꼬임 수정2

### DIFF
--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -81,8 +81,8 @@ export default function useClientProfilePostForm() {
 
          if (res.data.isProfileCompleted === true) {
             // user 상태 즉각 반영: refreshUser와 alert 순서 바꾸면 안 됨
-            refreshUser();
-            alert("프로필이 등록되었습니다.");
+            await refreshUser();
+            // alert("프로필이 등록되었습니다.");
             router.replace("/mover-search");
          }
       } catch (error) {


### PR DESCRIPTION
## 작업 개요
- 배포 환경에서 프로필 등록 순서 꼬임 수정2

---

## 작업 상세 내용
- [x] 실행 순서가 꼬이지 않도록 refreshUser에 await 붙임
- [x] 실행 순서가 꼬이지 않도록 임시로 경고창 삭제함

---

## 🗂️ 수정한 파일
- `src/lib/hooks/useClientProfilePostForm.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- 나머지 오류는 수정되었는데 해당 오류만 (배포 환경에) 남았습니다. 시험 삼아 PR 올리니 승인 부탁드립니다.
