### PR TITLE
fix: 기사님 프로필/기본정보 관련 유효성 및 기타 로직 수정

### DIFF
--- a/src/components/domain/profile/MoverProfileUpdateForms.tsx
+++ b/src/components/domain/profile/MoverProfileUpdateForms.tsx
@@ -7,8 +7,12 @@ import TextAreaInputField from "./TextAreaInputField";
 import ButtonInputField from "./ButtonInputField";
 import SolidButton from "@/components/common/SolidButton";
 import useMoverProfileUpdateForm from "@/lib/hooks/useMoverProfileUpdateForm";
+import OutlinedButton from "@/components/common/OutlinedButton";
+import { useRouter } from "next/navigation";
 
 export default function MoverProfileUpdateForm() {
+   const router = useRouter();
+
    const {
       register,
       control,
@@ -107,10 +111,13 @@ export default function MoverProfileUpdateForm() {
             </div>
          </div>
 
-         <div className="mt-17 lg:pl-185">
+         <div className="mt-17 flex flex-col gap-2 lg:mt-16 lg:flex-row-reverse lg:gap-8">
             <SolidButton disabled={!isValid || isLoading} type="submit">
                {isLoading ? "수정 중..." : "수정하기"}
             </SolidButton>
+            <OutlinedButton onClick={() => router.push("/dashboard")}>
+               취소
+            </OutlinedButton>
          </div>
       </form>
    );

--- a/src/lib/hooks/useSignInForm.ts
+++ b/src/lib/hooks/useSignInForm.ts
@@ -41,7 +41,7 @@ export default function useSignInForm() {
          if (!res.data?.isProfileCompleted) {
             router.replace("/profile/create");
          } else {
-            router.replace("/mover-search");
+            router.replace("/received-requests");
          }
       } catch (error) {
          console.error("로그인 실패: ", error);

--- a/src/lib/schemas/dashboard.schema.ts
+++ b/src/lib/schemas/dashboard.schema.ts
@@ -10,16 +10,30 @@ type ExtendedRefinementCtx = RefinementCtx & {
    };
 };
 
+const allowedDomains = ["gmail.com", "naver.com", "daum.net"];
+
 //기사님 기본정보 수정 시 사용
 const rawMoverBasicInfoSchema = {
    name: z
       .string()
       .min(2, "본명은 2자 이상 입력해주세요")
       .max(4, "본명은 4자 이하로 입력해주세요"),
-   email: z.string().email("올바른 이메일 형식이 아닙니다."),
+   email: z
+      .string()
+      .email("올바른 이메일 형식이 아닙니다.")
+      .refine(
+         (email) => {
+            const domain = email.split("@")[1];
+            return allowedDomains.includes(domain);
+         },
+         {
+            message: "test, gmail, naver, daum 도메인만 허용합니다.",
+         },
+      ),
    phone: z
       .string()
       .min(10, "최소 10자리 이상이어야 합니다.")
+      .max(11, "최대 11자리 이하여야 합니다.")
       .regex(/^\d+$/, "숫자만 입력해주세요."),
    newPassword: z.string().optional(),
    newPasswordConfirmation: z.string().optional(),


### PR DESCRIPTION
## 작업 개요
- 기본 배포용 구조 세팅 및 전역 스타일 적용

---

## 작업 상세 내용
- [x] 프로필 수정 페이지에서 취소 버튼 생성
- [x] 기본정보에서 전화번호 길이 유효성 추가

---

## 🗂️ 수정한 파일
- `src/components/domain/profile/MoverProfileUpdateForms.tsx`
- `src/lib/hooks/useSignInForm.ts`
- `src/lib/schemas/dashboard.schema.ts`

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항
- 기사님 로그인하면 “받은 요청 페이지”로 이동 안됨 > **(확인 중)**