### PR TITLE
feat: 보낸 견적 상세 개선 및 받은 요청 UI 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,6 +1552,13 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/@types/ms": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+         "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/@types/node": {
          "version": "20.19.9",
          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",

--- a/src/app/[locale]/(with-protected)/my-quotes/mover/[id]/page.tsx
+++ b/src/app/[locale]/(with-protected)/my-quotes/mover/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import SentQuoteDetail from "@/components/domain/my-quotes/SentQuoteDetail";
 

--- a/src/app/[locale]/(with-protected)/my-quotes/mover/[id]/page.tsx
+++ b/src/app/[locale]/(with-protected)/my-quotes/mover/[id]/page.tsx
@@ -11,9 +11,5 @@ export default async function Page({
 
    if (!id) return notFound();
 
-   return (
-      <Suspense fallback={<div>잠시만 기다려 주세요...</div>}>
-         <SentQuoteDetail id={id} />
-      </Suspense>
-   );
+   return <SentQuoteDetail id={id} />;
 }

--- a/src/components/common/ToastPopup.tsx
+++ b/src/components/common/ToastPopup.tsx
@@ -1,28 +1,107 @@
-import React from "react";
-import InfoIcon from "@/assets/images/infoIcon.svg";
-import Image from "next/image";
+/**
+ * ToastPopup - 사용자 알림용 토스트 UI 컴포넌트
+ *
+ * 목적:
+ * - 사용자에게 특정 액션의 성공 또는 실패 메시지를 간단하게 시각적으로 전달합니다.
+ *
+ * 특징:
+ * - framer-motion 기반 애니메이션으로 부드러운 등장/퇴장 효과 제공
+ * - 상단에서 내려와 3초간 표시 후 자동 사라짐
+ * - 성공(success: true) 시 파란색 테마, 실패 시 빨간색 테마 적용
+ *
+ * Props:
+ * @prop {string} text - 화면에 표시할 알림 텍스트
+ * @prop {boolean} success - 성공 여부 (true: 파란색, false: 빨간색 테마)
+ *
+ * 기본 사용 예시:
+ * ```tsx
+ * const [toast, setToast] = useState<{ text: string; success: boolean } | null>(null);
+ *
+ * {toast && <ToastPopup text={toast.text} success={toast.success} />}
+ * ```
+ *
+ * 주의 사항:
+ * 동일한 메시지를 연속으로 띄우고 싶다면, `toast` 객체에 고유한 `id` 값을 포함하여 리렌더링을 유도해야 합니다.
+ *
+ * 고유 ID를 활용한 예시:
+ * ```tsx
+ * const [toast, setToast] = useState<{
+ *   id: number;
+ *   text: string;
+ *   success: boolean;
+ * } | null>(null);
+ *
+ * // 메시지 표시
+ * setToast({
+ *   id: Date.now(), // 또는 uuid()
+ *   text: "저장 완료",
+ *   success: true
+ * });
+ *
+ * // 렌더링 시 key 부여
+ * {toast && (
+ *   <ToastPopup
+ *     key={toast.id}
+ *     text={toast.text}
+ *     success={toast.success}
+ *   />
+ * )}
+ * ```
+ */
 
-export default function ToastPopup({
-   children,
-   className,
-}: {
-   children: React.ReactNode;
-   className?: string;
-}) {
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { MdErrorOutline } from "react-icons/md";
+import { FaRegCircleCheck } from "react-icons/fa6";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ToastPopupProps {
+   text: string;
+   success: boolean;
+}
+
+export default function ToastPopup({ text, success }: ToastPopupProps) {
+   const [visible, setVisible] = useState(true);
+
+   useEffect(() => {
+      const timer = setTimeout(() => {
+         setVisible(false);
+      }, 3000);
+      return () => clearTimeout(timer);
+   }, []);
+
+   const icon = success ? (
+      <FaRegCircleCheck className="h-5 w-5 md:h-6 md:w-6" />
+   ) : (
+      <MdErrorOutline className="h-5 w-5 md:h-6 md:w-6" />
+   );
+   const bgColor = success ? "bg-primary-blue-100" : "bg-red-100";
+   const borderColor = success ? "outline-primary-blue-300" : "outline-red-300";
+   const textColor = success ? "text-primary-blue-300" : "text-red-500";
+
    return (
-      <div
-         className={`fixed top-16 left-1/2 z-50 -translate-x-1/2 opacity-100 transition-opacity duration-300 lg:top-[114px] ${className}`}
-      >
-         <div className="bg-primary-blue-100 outline-primary-blue-300 flex h-12 w-80 items-center justify-start gap-2 rounded-xl px-6 py-2.5 shadow-[2px_2px_10px_0px_rgba(46,46,46,0.04)] outline outline-offset-[-1px] md:w-155 md:gap-4 lg:h-[62px] lg:w-[955px]">
-            <Image
-               src={InfoIcon}
-               alt="토스트 알림"
-               className="aspect-square md:w-6"
-            />
-            <div className="text-primary-blue-300 font-semibold max-md:text-xs">
-               {children}
-            </div>
-         </div>
-      </div>
+      <AnimatePresence>
+         {visible && (
+            <motion.div
+               className="fixed top-16 left-1/2 z-40 -translate-x-1/2 lg:top-28"
+               initial={{ opacity: 0, y: -10 }}
+               animate={{ opacity: 1, y: 0 }}
+               exit={{ opacity: 0, y: 20 }}
+               transition={{ duration: 0.5, ease: "easeInOut" }}
+            >
+               <div
+                  className={`${bgColor} ${borderColor} flex items-center gap-1.5 rounded-xl px-4 py-2.5 outline outline-offset-[-1px] lg:gap-2 lg:px-5 lg:py-3`}
+               >
+                  <div className={textColor}>{icon}</div>
+                  <div
+                     className={`${textColor} text-14-medium lg:text-16-medium text-nowrap`}
+                  >
+                     {text}
+                  </div>
+               </div>
+            </motion.div>
+         )}
+      </AnimatePresence>
    );
 }

--- a/src/components/domain/my-quotes/ConfirmedButton.tsx
+++ b/src/components/domain/my-quotes/ConfirmedButton.tsx
@@ -11,26 +11,48 @@ export default function ConfirmedButton({
 }: {
    estimateId: string;
 }) {
-   const [isModal, setIsModal] = useState<boolean>(false);
+   const [toast, setToast] = useState<{
+      id: number;
+      text: string;
+      success: boolean;
+   } | null>(null);
+
    const router = useRouter();
 
    const handleClickConfirmed = async (estimateId: string) => {
       try {
-         const result = await postClientConfirmedQuote(estimateId);
+         await postClientConfirmedQuote(estimateId);
 
-         setIsModal(true);
+         setToast({
+            id: Date.now(), // 같은 메시지도 연속 노출 가능하게
+            text: "견적이 확정되었습니다",
+            success: true,
+         });
+
          router.push("/ko/my-quotes/client?tab=2");
-         return result;
       } catch (e) {
-         throw e;
+         setToast({
+            id: Date.now(),
+            text: "견적 확정에 실패했습니다",
+            success: false,
+         });
+         console.error(e);
       }
    };
 
-   if (isModal) return <ToastPopup>견적이 확정되었습니다</ToastPopup>;
-
    return (
-      <SolidButton onClick={() => handleClickConfirmed(estimateId)}>
-         견적 확정하기
-      </SolidButton>
+      <>
+         <SolidButton onClick={() => handleClickConfirmed(estimateId)}>
+            견적 확정하기
+         </SolidButton>
+
+         {toast && (
+            <ToastPopup
+               key={toast.id}
+               text={toast.text}
+               success={toast.success}
+            />
+         )}
+      </>
    );
 }

--- a/src/components/domain/my-quotes/DesignatedBadge.tsx
+++ b/src/components/domain/my-quotes/DesignatedBadge.tsx
@@ -1,0 +1,27 @@
+"use client";
+import MoveChip from "@/components/common/MoveChip";
+import { useAuth } from "@/context/AuthContext";
+
+type DesignatedRequestItem = {
+   moverId: string;
+};
+
+export default function DesignatedBadge({
+   designatedRequest,
+}: {
+   designatedRequest: DesignatedRequestItem[];
+}) {
+   const { user } = useAuth();
+
+   if (!user) return null;
+
+   const isDesignated = designatedRequest.some(
+      (mover) => mover.moverId === user.id,
+   );
+
+   console.log("designatedRequest", designatedRequest);
+   console.log("user.id", user.id);
+   console.log("isDesignated", isDesignated);
+
+   return isDesignated ? <MoveChip type="DESIGNATED" /> : null;
+}

--- a/src/components/domain/my-quotes/SentQuoteDetail.tsx
+++ b/src/components/domain/my-quotes/SentQuoteDetail.tsx
@@ -5,7 +5,6 @@ import SocialShareGroup from "@/components/common/SocialShareGroup";
 import SentQuoteDetailContent from "./SentQuoteDetailContent";
 import { Suspense } from "react";
 import SentQuoteDetailSkeleton from "./SentQuoteDetailSkeleton";
-import ToastPopup from "@/components/common/ToastPopup";
 
 export default async function SentQuoteDetail({ id }: { id: string }) {
    const estimate = await getSentEstimateDetail(id);

--- a/src/components/domain/my-quotes/SentQuoteDetail.tsx
+++ b/src/components/domain/my-quotes/SentQuoteDetail.tsx
@@ -1,120 +1,25 @@
-import MoveChip from "@/components/common/MoveChip";
 import PageTitle from "@/components/layout/PageTitle";
 import { getSentEstimateDetail } from "@/lib/api/estimate/requests/getSentEstimateDetail";
 import { notFound } from "next/navigation";
-import MoveTextCard from "./MoveTextCard";
 import SocialShareGroup from "@/components/common/SocialShareGroup";
+import SentQuoteDetailContent from "./SentQuoteDetailContent";
+import { Suspense } from "react";
+import SentQuoteDetailSkeleton from "./SentQuoteDetailSkeleton";
+import ToastPopup from "@/components/common/ToastPopup";
 
 export default async function SentQuoteDetail({ id }: { id: string }) {
    const estimate = await getSentEstimateDetail(id);
 
    if (!estimate || !estimate.request) return notFound();
 
-   const { request, price, isClientConfirmed, createdAt } = estimate;
-
-   console.log(request, price, isClientConfirmed);
-
    return (
       <div>
-         <PageTitle title={"견적 상세"} />
+         <PageTitle title="견적 상세" />
          <div className="mt-4 lg:flex lg:gap-40">
             <article className="flex flex-col gap-6 lg:flex-1 lg:gap-10">
-               <div className="border-line-100 rounded-2xl border bg-white px-3.5 py-4 lg:px-6 lg:py-5">
-                  <div className="flex flex-col gap-4">
-                     <div className="flex items-center gap-2 lg:gap-3">
-                        {isClientConfirmed && (
-                           <div className="w-fit rounded-sm bg-gray-800 px-1.5 py-0.5 lg:py-1">
-                              <span className="text-13-semibold lg:text-16-semibold">
-                                 견적 확정
-                              </span>
-                           </div>
-                        )}
-                        <MoveChip type={request.moveType} />
-                        {request.designatedRequest.length > 0 && (
-                           <MoveChip type="DESIGNATED" />
-                        )}
-                     </div>
-                     <div>
-                        <p className="text-16-semibold lg:text-20-semibold">
-                           {request.client.name} 고객님
-                        </p>
-                     </div>
-                     <div className="flex items-center gap-2 md:hidden">
-                        <MoveTextCard text="이사일" />
-                        <span className="text-14-medium lg:text-18-medium">
-                           {request.moveDate.slice(0, 10)} (
-                           {
-                              "일월화수목금토"[
-                                 new Date(request.moveDate).getDay()
-                              ]
-                           }
-                           )
-                        </span>
-                     </div>
-                     <div className="border-line-100 border"></div>
-                     <div className="flex gap-3.5 lg:gap-4 [&_div]:flex [&_div]:items-center [&_div]:gap-2">
-                        <div className="!hidden md:!flex">
-                           <MoveTextCard text="이사일" />
-                           <span className="text-14-medium lg:text-18-medium">
-                              {request.moveDate.slice(0, 10)} (
-                              {
-                                 "일월화수목금토"[
-                                    new Date(request.moveDate).getDay()
-                                 ]
-                              }
-                              )
-                           </span>
-                        </div>
-                        <div>
-                           <MoveTextCard text="출발" />
-                           <span className="text-14-medium lg:text-18-medium">
-                              {request.fromAddress.slice(0, 6)}
-                           </span>
-                        </div>
-                        <div>
-                           <MoveTextCard text="도착" />
-                           <span className="text-14-medium lg:text-18-medium">
-                              {request.toAddress.slice(0, 6)}
-                           </span>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-               <div className="border-line-100 border lg:hidden"></div>
-               <div className="lg:hidden">
-                  <SocialShareGroup text="견적서 공유하기" />
-               </div>
-               <div className="border-line-100 border"></div>
-               <div className="flex flex-col gap-4 lg:gap-6">
-                  <span className="text-16-semibold lg:text-24-semibold">
-                     견적가
-                  </span>
-                  <p className="text-20-bold lg:text-32-bold">
-                     {Number(price).toLocaleString()}원
-                  </p>
-               </div>
-               <div className="border-line-100 border"></div>
-               <div>
-                  <PageTitle title={"견적 정보"} />
-                  <ul className="bg-bg-100 border-line-100 [&_label]:text-14-regular [&_span]:text-14-regular [&_span]:lg:text-18-regular [&_label]:lg:text-18-regular mt-4 flex flex-col gap-2.5 rounded-2xl border px-5 py-4 lg:gap-4 lg:px-6 lg:py-5 [&_label]:min-w-16 [&_label]:text-gray-300 [&_label]:lg:min-w-22 [&_li]:flex [&_li]:items-center [&_li]:gap-10">
-                     <li>
-                        <label>견적 요청일</label>
-                        <span>{createdAt.slice(0, 10)}</span>
-                     </li>
-                     <li>
-                        <label>서비스</label>
-                        <span>{request.moveType}이사</span>
-                     </li>
-                     <li>
-                        <label>출발지</label>
-                        <span>{request.fromAddress}</span>
-                     </li>
-                     <li>
-                        <label>도착지</label>
-                        <span>{request.toAddress}</span>
-                     </li>
-                  </ul>
-               </div>
+               <Suspense fallback={<SentQuoteDetailSkeleton />}>
+                  <SentQuoteDetailContent id={id} />
+               </Suspense>
             </article>
             <article className="hidden h-fit w-60 lg:block">
                <SocialShareGroup text="견적서 공유하기" />

--- a/src/components/domain/my-quotes/SentQuoteDetailContent.tsx
+++ b/src/components/domain/my-quotes/SentQuoteDetailContent.tsx
@@ -1,0 +1,111 @@
+import MoveChip from "@/components/common/MoveChip";
+import { getSentEstimateDetail } from "@/lib/api/estimate/requests/getSentEstimateDetail";
+import { notFound } from "next/navigation";
+import MoveTextCard from "./MoveTextCard";
+import SocialShareGroup from "@/components/common/SocialShareGroup";
+import DesignatedBadge from "./DesignatedBadge";
+import PageTitle from "@/components/layout/PageTitle";
+
+const moveTypeMap: Record<string, string> = {
+   OFFICE: "사무실",
+   HOME: "가정",
+   SMALL: "소형",
+};
+
+export default async function SentQuoteDetailContent({ id }: { id: string }) {
+   const estimate = await getSentEstimateDetail(id);
+   if (!estimate || !estimate.request) return notFound();
+
+   const { request, price, isClientConfirmed, createdAt } = estimate;
+
+   return (
+      <>
+         <div className="border-line-100 rounded-2xl border bg-white px-3.5 py-4 lg:px-6 lg:py-5">
+            <div className="flex flex-col gap-4">
+               <div className="flex items-center gap-2 lg:gap-3">
+                  {isClientConfirmed && (
+                     <div className="w-fit rounded-sm bg-gray-800 px-1.5 py-0.5 lg:py-1">
+                        <span className="text-13-semibold lg:text-16-semibold">
+                           견적 확정
+                        </span>
+                     </div>
+                  )}
+                  <MoveChip type={request.moveType} />
+                  <DesignatedBadge
+                     designatedRequest={request.designatedRequest}
+                  />
+               </div>
+               <p className="text-16-semibold lg:text-20-semibold">
+                  {request.client.name} 고객님
+               </p>
+               <div className="flex items-center gap-2 md:hidden">
+                  <MoveTextCard text="이사일" />
+                  <span className="text-14-medium lg:text-18-medium">
+                     {request.moveDate.slice(0, 10)} (
+                     {"일월화수목금토"[new Date(request.moveDate).getDay()]})
+                  </span>
+               </div>
+               <div className="border-line-100 border"></div>
+               <div className="flex gap-3.5 lg:gap-4 [&_div]:flex [&_div]:items-center [&_div]:gap-2">
+                  <div className="!hidden md:!flex">
+                     <MoveTextCard text="이사일" />
+                     <span className="text-14-medium lg:text-18-medium">
+                        {request.moveDate.slice(0, 10)} (
+                        {"일월화수목금토"[new Date(request.moveDate).getDay()]})
+                     </span>
+                  </div>
+                  <div>
+                     <MoveTextCard text="출발" />
+                     <span className="text-14-medium lg:text-18-medium">
+                        {request.fromAddress.slice(0, 6)}
+                     </span>
+                  </div>
+                  <div>
+                     <MoveTextCard text="도착" />
+                     <span className="text-14-medium lg:text-18-medium">
+                        {request.toAddress.slice(0, 6)}
+                     </span>
+                  </div>
+               </div>
+            </div>
+         </div>
+
+         <div className="border-line-100 border lg:hidden" />
+         <div className="lg:hidden">
+            <SocialShareGroup text="견적서 공유하기" />
+         </div>
+         <div className="border-line-100 border" />
+
+         <div className="flex flex-col gap-4 lg:gap-6">
+            <span className="text-16-semibold lg:text-24-semibold">견적가</span>
+            <p className="text-20-bold lg:text-32-bold">
+               {Number(price).toLocaleString()}원
+            </p>
+         </div>
+
+         <div className="border-line-100 border" />
+
+         <div>
+            <PageTitle title="견적 정보" />
+            <ul className="bg-bg-100 border-line-100 [&_label]:text-14-regular [&_span]:text-14-regular [&_span]:lg:text-18-regular [&_label]:lg:text-18-regular mt-4 flex flex-col gap-2.5 rounded-2xl border px-5 py-4 lg:gap-4 lg:px-6 lg:py-5 [&_label]:min-w-16 [&_label]:text-gray-300 [&_label]:lg:min-w-22 [&_li]:flex [&_li]:items-center [&_li]:gap-10">
+               <li>
+                  <label>견적 요청일</label>
+                  <span>{createdAt.slice(0, 10)}</span>
+               </li>
+               <li>
+                  <label>서비스</label>
+                  <span>{moveTypeMap[request.moveType]}이사</span>
+               </li>
+               <li>
+                  <label>출발지</label>
+                  <span>{request.fromAddress}</span>
+               </li>
+               <li>
+                  <label>도착지</label>
+                  <span>{request.toAddress}</span>
+               </li>
+            </ul>
+         </div>
+      </>
+   );
+}

--- a/src/components/domain/my-quotes/SentQuoteDetailSkeleton.tsx
+++ b/src/components/domain/my-quotes/SentQuoteDetailSkeleton.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+export default function SentQuoteDetailSkeleton() {
+   return (
+      <div className="animate-pulse">
+         {/* 카드 상단 */}
+         <div className="border-line-100 rounded-2xl border bg-white px-4 py-5 lg:px-6 lg:py-6">
+            <div className="flex flex-col gap-6">
+               {/* 뱃지 영역 */}
+               <div className="flex items-center gap-3 lg:gap-4">
+                  <div className="bg-primary-blue-200 h-6 w-16 rounded-sm" />
+               </div>
+
+               {/* 고객 이름 */}
+               <div className="h-5 w-40 rounded bg-gray-200" />
+
+               {/* 모바일 전용 이사일 */}
+               <div className="flex items-center gap-3 md:hidden">
+                  <div className="h-5 w-10 rounded bg-gray-100" />
+                  <div className="h-5 w-36 rounded bg-gray-200" />
+               </div>
+
+               <div className="border-line-100 border" />
+
+               {/* 주소 정보 */}
+               <div className="flex gap-4 lg:gap-6 [&_div]:flex [&_div]:items-center [&_div]:gap-2">
+                  <div className="!hidden md:!flex">
+                     <div className="h-5 w-10 rounded bg-gray-100" />
+                     <div className="h-5 w-36 rounded bg-gray-200" />
+                  </div>
+                  <div>
+                     <div className="h-5 w-10 rounded bg-gray-100" />
+                     <div className="h-5 w-20 rounded bg-gray-200" />
+                  </div>
+                  <div>
+                     <div className="h-5 w-10 rounded bg-gray-100" />
+                     <div className="h-5 w-20 rounded bg-gray-200" />
+                  </div>
+               </div>
+            </div>
+         </div>
+
+         <div className="border-line-100 my-6 border lg:hidden" />
+
+         {/* 모바일 공유 버튼 */}
+         <div className="mb-6 lg:hidden">
+            <div className="bg-primary-blue-100 h-10 w-40 rounded-xl" />
+         </div>
+
+         <div className="border-line-100 my-6 border" />
+
+         {/* 견적가 */}
+         <div className="flex flex-col gap-5 lg:gap-8 lg:py-4">
+            <div className="h-5 w-20 rounded bg-gray-100" />
+            <div className="h-8 w-40 rounded bg-gray-200" />
+         </div>
+
+         <div className="border-line-100 my-6 border" />
+
+         {/* 견적 정보 */}
+         <div>
+            <div className="mb-5 h-6 w-32 rounded bg-gray-100" />
+            <ul className="bg-bg-100 border-line-100 mt-5 flex flex-col gap-3 rounded-2xl border px-5 py-4 lg:gap-5 lg:px-6 lg:py-5">
+               {Array.from({ length: 4 }).map((_, idx) => (
+                  <li key={idx} className="flex items-center gap-10">
+                     <div className="h-4 w-16 rounded bg-gray-100" />
+                     <div className="h-4 w-40 rounded bg-gray-200" />
+                  </li>
+               ))}
+            </ul>
+         </div>
+      </div>
+   );
+}

--- a/src/components/domain/received-requests/ReceivedRequestsList.tsx
+++ b/src/components/domain/received-requests/ReceivedRequestsList.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import RequestCard from "./RequestCard";
 import { ReceivedRequest, ReceivedRequestsProps } from "@/lib/types";
 import { useReceivedRequestsQuery } from "@/lib/api/request/query";
 import SkeletonLayout from "@/components/common/SkeletonLayout";
 import RequestCardSkeleton from "./RequestCardSkeleton";
+import ToastPopup from "@/components/common/ToastPopup";
 
 export default function ReceivedRequestsList({
    moveType,
@@ -16,6 +17,11 @@ export default function ReceivedRequestsList({
    onLoadingChange,
 }: ReceivedRequestsProps) {
    const observerRef = useRef<HTMLDivElement | null>(null);
+   const [toast, setToast] = useState<{
+      id: number;
+      text: string;
+      success: boolean;
+   } | null>(null);
 
    const {
       data,
@@ -63,7 +69,7 @@ export default function ReceivedRequestsList({
          <div className="flex flex-col gap-6 md:gap-8 lg:gap-12">
             {data?.pages.map((page) =>
                (page as { requests: ReceivedRequest[] }).requests.map((req) => (
-                  <RequestCard key={req.id} req={req} />
+                  <RequestCard key={req.id} req={req} setToast={setToast} />
                )),
             )}
          </div>
@@ -78,6 +84,13 @@ export default function ReceivedRequestsList({
                </p>
             )}
          </div>
+         {toast && (
+            <ToastPopup
+               key={toast.id}
+               text={toast.text}
+               success={toast.success}
+            />
+         )}
       </>
    );
 }

--- a/src/components/domain/received-requests/RequestActionModal.tsx
+++ b/src/components/domain/received-requests/RequestActionModal.tsx
@@ -19,6 +19,10 @@ interface Props {
    isOpen: boolean;
    onClose: () => void;
    modalType: "accept" | "reject";
+   setToast: (
+      toast: { id: number; text: string; success: boolean } | null,
+   ) => void;
+
    request: ReceivedRequest;
    requestId: string;
    clientId: string;
@@ -28,6 +32,7 @@ export default function RequestActionModal({
    isOpen,
    onClose,
    modalType,
+   setToast,
    request,
    requestId,
    clientId,
@@ -74,6 +79,14 @@ export default function RequestActionModal({
       } catch (error) {
          console.error("요청 실패:", error);
       } finally {
+         setToast({
+            id: Date.now(),
+            text:
+               modalType === "accept"
+                  ? "고객님께 견적을 성공적으로 발송했습니다."
+                  : "견적 요청을 반려 처리했습니다.",
+            success: true,
+         });
          onClose();
          reset();
       }

--- a/src/components/domain/received-requests/RequestCard.tsx
+++ b/src/components/domain/received-requests/RequestCard.tsx
@@ -6,7 +6,15 @@ import MoveChip, { ChipType } from "@/components/common/MoveChip";
 import MoveTextCard from "../my-quotes/MoveTextCard";
 import RequestActionModal from "./RequestActionModal";
 
-export default function RequestCard({ req }: { req: ReceivedRequest }) {
+export default function RequestCard({
+   req,
+   setToast,
+}: {
+   req: ReceivedRequest;
+   setToast: (
+      toast: { id: number; text: string; success: boolean } | null,
+   ) => void;
+}) {
    const [isModalOpen, setIsModalOpen] = useState(false);
    const [modalType, setModalType] = useState<"accept" | "reject" | null>(null);
 
@@ -19,7 +27,7 @@ export default function RequestCard({ req }: { req: ReceivedRequest }) {
       setIsModalOpen(false);
       setModalType(null);
    };
-   
+
    return (
       <>
          {/* 요청 카드 UI */}
@@ -77,6 +85,7 @@ export default function RequestCard({ req }: { req: ReceivedRequest }) {
                isOpen={isModalOpen}
                onClose={closeModal}
                modalType={modalType}
+               setToast={setToast}
                request={req}
                requestId={req.id}
                clientId={req.clientId}


### PR DESCRIPTION
## 작업 개요
보낸 견적 상세 페이지의 UI를 Skeleton 및 Content로 분리하고,
받은 요청 카드 및 모달을 리팩토링하였으며,
ToastPopup 공통컴포넌트 리팩토링

## 작업 상세 내용
- `SentQuoteDetail` UI 분리: `Skeleton`, `Content`, `DesignatedBadge` 컴포넌트 추가
- `RequestCard`, `RequestActionModal` 등 받은 요청 관련 UI 구조 개선
- 서비스 유형(`OFFICE`, `HOUSE`, `ONE_ROOM`)에 대한 한글 매핑 처리
- `ToastPopup` 연속 렌더링 시 동일 메시지도 다시 뜨도록 `key` 처리
- 기타 UI 정리 및 스타일 개선

## 수정한 파일
- `src/app/[locale]/(with-protected)/my-quotes/mover/[id]/page.tsx`
- `src/components/common/ToastPopup.tsx`
- `src/components/domain/my-quotes/SentQuoteDetail.tsx`
- `src/components/domain/received-requests/ReceivedRequestsList.tsx`
- `src/components/domain/received-requests/RequestActionModal.tsx`
- `src/components/domain/received-requests/RequestCard.tsx`
- `src/components/domain/request/FormWizard.tsx`

## 새로 작성한 파일
- `src/components/domain/my-quotes/SentQuoteDetailSkeleton.tsx`
- `src/components/domain/my-quotes/SentQuoteDetailContent.tsx`
- `src/components/domain/my-quotes/DesignatedBadge.tsx`

## 기타 참고 사항
- `ToastPopup` 사용 시 동일 메시지에 대해서도 리렌더링이 필요하면 key 지정 필수
- 이후 `받은 요청` 페이지 전반 리팩토링과 애니메이션 처리 예정