### PR TITLE
feat: 내 견적 관리 탭 페이지네이션 기능 구현 (프론트엔드 연동)

### DIFF
--- a/src/app/[locale]/(with-protected)/my-quotes/mover/page.tsx
+++ b/src/app/[locale]/(with-protected)/my-quotes/mover/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
    const searchParams = useSearchParams();
 
    const tab = searchParams.get("tab");
-   const activeTab = tab === "2" ? "2" : "1";
+   const activeTab = tab === "1" ? "1" : "2";
 
    useEffect(() => {
       if (!tab) {

--- a/src/components/common/pagination.tsx
+++ b/src/components/common/pagination.tsx
@@ -42,7 +42,9 @@ export default function Pagination({
       return () => window.removeEventListener("resize", update);
    }, []);
 
-   if (totalPages <= 1) return null;
+   if (!totalPages || totalPages < 1) {
+      return <nav className="my-6 flex h-10 items-center justify-center" />;
+   }
 
    const pagesToShow = getPageRange(page, totalPages, maxPages);
    const hasLeftDots = pagesToShow[0] > 2;

--- a/src/components/domain/my-quotes/RejectedRequestsList.tsx
+++ b/src/components/domain/my-quotes/RejectedRequestsList.tsx
@@ -1,51 +1,44 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { getRejectedEstimates } from "@/lib/api/estimate/requests/getRejectedEstimates";
 import EmptyState from "@/components/common/EmptyState";
 import QuoteCard from "./QuoteCard";
-import { MyEstimateDetail } from "@/lib/types";
 import SkeletonLayout from "@/components/common/SkeletonLayout";
 import RejectedRequestsSkeleton from "./RejectedRequestsSkeleton";
+import { useState } from "react";
+import { MyEstimateDetail } from "@/lib/types";
+import Pagination from "@/components/common/pagination";
+import { useRejectedEstimates } from "@/lib/api/estimate/query";
 
 export default function RejectedRequestsList() {
-   const [estimates, setEstimates] = useState<MyEstimateDetail[] | null>(null);
-   const [isLoading, setIsLoading] = useState(true);
+   const [page, setPage] = useState(1);
+   const { data, isLoading } = useRejectedEstimates(page);
 
-   useEffect(() => {
-      const fetchData = async () => {
-         const response = await getRejectedEstimates();
-         setEstimates(response?.data ?? []);
-         setIsLoading(false);
-      };
-
-      fetchData();
-   }, []);
-
-   if (isLoading) {
-      return (
-         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
-            <SkeletonLayout
-               count={6}
-               SkeletonComponent={RejectedRequestsSkeleton}
-            />
-         </div>
-      );
-   }
-
-   const hasEstimates = estimates && estimates.length > 0;
+   const estimates = data?.data ?? [];
+   const totalPages = data?.totalPages ?? 1;
+   const hasEstimates = estimates.length > 0;
 
    return (
       <div>
-         {hasEstimates ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
-               {estimates.map((est) => (
+         {/* 카드 영역 */}
+         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
+            {isLoading ? (
+               <SkeletonLayout
+                  count={6}
+                  SkeletonComponent={RejectedRequestsSkeleton}
+               />
+            ) : hasEstimates ? (
+               estimates.map((est: MyEstimateDetail) => (
                   <QuoteCard key={est.id} estimate={est} />
-               ))}
-            </div>
-         ) : (
-            <EmptyState message="아직 반려한 견적이 없습니다." />
-         )}
+               ))
+            ) : (
+               <EmptyState message="아직 반려한 견적이 없습니다." />
+            )}
+         </div>
+         <Pagination
+            page={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+         />
       </div>
    );
 }

--- a/src/components/domain/my-quotes/RejectedRequestsSkeleton.tsx
+++ b/src/components/domain/my-quotes/RejectedRequestsSkeleton.tsx
@@ -1,5 +1,5 @@
 "use client";
-export default async function RejectedRequestsSkeleton() {
+export default function RejectedRequestsSkeleton() {
    return (
       <div className="animate-pulse rounded-2xl bg-white px-3.5 py-4 lg:px-6 lg:py-5">
          {/* 상단 칩 영역 */}

--- a/src/components/domain/my-quotes/SentQuotesList.tsx
+++ b/src/components/domain/my-quotes/SentQuotesList.tsx
@@ -1,48 +1,46 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { getSentEstimates } from "@/lib/api/estimate/requests/getSentEstimates";
-import EmptyState from "@/components/common/EmptyState";
+import { useState } from "react";
+import { useSentEstimates } from "@/lib/api/estimate/query";
 import QuoteCard from "./QuoteCard";
-import { MyEstimateDetail } from "@/lib/types";
+import Pagination from "@/components/common/pagination";
 import SkeletonLayout from "@/components/common/SkeletonLayout";
 import SentQuotesSkeleton from "./SentQuotesSkeleton";
+import EmptyState from "@/components/common/EmptyState";
+import { MyEstimateDetail } from "@/lib/types";
 
 export default function SentQuotesList() {
-   const [estimates, setEstimates] = useState<MyEstimateDetail[] | null>(null);
-   const [isLoading, setIsLoading] = useState(true);
+   const [page, setPage] = useState(1);
+   const { data, isLoading } = useSentEstimates(page);
 
-   useEffect(() => {
-      const fetchData = async () => {
-         const response = await getSentEstimates();
-         setEstimates(response?.data ?? []);
-         setIsLoading(false);
-      };
-
-      fetchData();
-   }, []);
-
-   if (isLoading) {
-      return (
-         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
-            <SkeletonLayout count={6} SkeletonComponent={SentQuotesSkeleton} />
-         </div>
-      );
-   }
-
-   const hasEstimates = estimates && estimates.length > 0;
+   const estimates = data?.data ?? [];
+   const totalPages = data?.totalPages ?? 1;
+   const hasEstimates = estimates.length > 0;
 
    return (
       <div>
-         {hasEstimates ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
-               {estimates.map((est) => (
+         {/* 카드 영역 */}
+         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
+            {isLoading ? (
+               <SkeletonLayout
+                  count={6}
+                  SkeletonComponent={SentQuotesSkeleton}
+               />
+            ) : hasEstimates ? (
+               estimates.map((est: MyEstimateDetail) => (
                   <QuoteCard key={est.id} estimate={est} />
-               ))}
-            </div>
-         ) : (
-            <EmptyState message="아직 보낸 견적이 없습니다." />
-         )}
+               ))
+            ) : (
+               <EmptyState message="아직 보낸 견적이 없습니다." />
+            )}
+         </div>
+
+         {/* 페이지네이션 항상 표시 */}
+         <Pagination
+            page={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+         />
       </div>
    );
 }

--- a/src/components/domain/my-quotes/SentQuotesSkeleton.tsx
+++ b/src/components/domain/my-quotes/SentQuotesSkeleton.tsx
@@ -1,5 +1,5 @@
 "use client";
-export default async function SentQuotesSkeleton() {
+export default function SentQuotesSkeleton() {
    return (
       <div className="animate-pulse rounded-2xl bg-white px-3.5 py-4 lg:px-6 lg:py-5">
          {/* 상단 칩 영역 */}

--- a/src/components/layout/HamburgerMenu.tsx
+++ b/src/components/layout/HamburgerMenu.tsx
@@ -45,7 +45,7 @@ export default function HamburgerMenu({
            ]
          : [
               { label: "받은 요청", href: "/received-requests" },
-              { label: "내 견적 관리", href: "/my-quotes/mover" },
+              { label: "내 견적 관리", href: "/my-quotes/mover?tab=1" },
            ]
       : [
            { label: "로그인", href: "/sign-in/client" },

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -123,7 +123,7 @@ export default function Header({ children }: { children?: React.ReactNode }) {
                         받은 요청
                      </Link>
                      <Link
-                        href="/my-quotes/mover"
+                        href="/my-quotes/mover?tab=1"
                         className={linkClass("/my-quotes/mover")}
                      >
                         내 견적 관리
@@ -197,18 +197,28 @@ export default function Header({ children }: { children?: React.ReactNode }) {
                      </div>
                      <div
                         ref={profileRef}
-                        className="relative size-6 lg:size-8"
+                        className="relative flex size-6 justify-center lg:size-8"
                      >
                         <button
                            onClick={() =>
                               setIsProfileDropDownOpen((prev) => !prev)
                            }
                         >
-                           <Image
-                              src={profileIcon}
-                              alt="profile"
-                              className="lg:w-full"
-                           />
+                           {user?.profileImage ? (
+                              <Image
+                                 src={user.profileImage}
+                                 alt="profile"
+                                 width={32}
+                                 height={32}
+                                 className="h-full w-full rounded-full"
+                              />
+                           ) : (
+                              <Image
+                                 src={profileIcon}
+                                 alt="default profile"
+                                 className="lg:w-full"
+                              />
+                           )}
                         </button>
                         {isProfileDropDownOpen && <ProfileDropDownMenu />}
                      </div>

--- a/src/lib/api/estimate/query.ts
+++ b/src/lib/api/estimate/query.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRejectedEstimates } from "./requests/getRejectedEstimates";
+import { getSentEstimates } from "./requests/getSentEstimates";
+
+export function useRejectedEstimates(page: number) {
+   return useQuery({
+      queryKey: ["rejectedEstimates", page],
+      queryFn: () => getRejectedEstimates(page),
+      refetchOnWindowFocus: false,
+      placeholderData: (prev) => prev,
+   });
+}
+
+export function useSentEstimates(page: number) {
+   return useQuery({
+      queryKey: ["sentEstimates", page],
+      queryFn: () => getSentEstimates(page),
+      refetchOnWindowFocus: false,
+      placeholderData: (prev) => prev,
+   });
+}

--- a/src/lib/api/estimate/requests/getRejectedEstimates.ts
+++ b/src/lib/api/estimate/requests/getRejectedEstimates.ts
@@ -1,18 +1,11 @@
 import { tokenFetch } from "@/lib/utils";
 import { delay } from "../../../../../delay";
 
-export async function getRejectedEstimates() {
-   await delay(3000);
-
-   try {
-      const data = await tokenFetch("/estimates/rejected", {
-         method: "GET",
-         cache: "no-store",
-      });
-
-      return data;
-   } catch (error) {
-      console.error("반려된 견적 목록을 불러오지 못했습니다.", error);
-      return [];
-   }
+export async function getRejectedEstimates(page = 1) {
+   await delay(500);
+   const data = await tokenFetch(`/estimates/rejected?page=${page}`, {
+      method: "GET",
+      cache: "no-store",
+   });
+   return data;
 }

--- a/src/lib/api/estimate/requests/getSentEstimates.ts
+++ b/src/lib/api/estimate/requests/getSentEstimates.ts
@@ -1,17 +1,13 @@
 import { tokenFetch } from "@/lib/utils";
 import { delay } from "../../../../../delay";
 
-export async function getSentEstimates() {
-   await delay(3000);
-   try {
-      const data = await tokenFetch("/estimates/sent", {
-         method: "GET",
-         cache: "no-store",
-      });
+export async function getSentEstimates(page: number = 1) {
+   await delay(500);
 
-      return data;
-   } catch (error) {
-      console.error("보낸 견적 목록을 불러오지 못했습니다.", error);
-      return [];
-   }
+   const res = await tokenFetch(`/estimates/sent?page=${page}`, {
+      method: "GET",
+      cache: "no-store",
+   });
+
+   return res;
 }


### PR DESCRIPTION
## 작업 개요
- 프론트엔드에서 내 견적 관리(보낸 견적/반려 견적) 탭에 페이지네이션 기능을 연동

---

## 작업 상세 내용
- [x] `useSentEstimates`, `useRejectedEstimates` 커스텀 훅을 `query.ts`에 분리하여 구성
- [x] 기존 목록 컴포넌트에 페이지 상태 및 `Pagination` 컴포넌트 연결
- [x] 백엔드 페이지네이션 로직(6개 단위)에 맞춰 동작 확인

---

## 🗂️ 수정한 파일
- `src/app/[locale]/(with-protected)/my-quotes/mover/page.tsx`
- `src/components/common/pagination.tsx`
- `src/components/domain/my-quotes/RejectedRequestsList.tsx`
- `src/components/domain/my-quotes/RejectedRequestsSkeleton.tsx`
- `src/components/domain/my-quotes/SentQuotesList.tsx`
- `src/components/domain/my-quotes/SentQuotesSkeleton.tsx`
- `src/components/layout/HamburgerMenu.tsx`
- `src/components/layout/Header.tsx`
- `src/lib/api/estimate/requests/getRejectedEstimates.ts`
- `src/lib/api/estimate/requests/getSentEstimates.ts`
---

## 🗂️ 새로 작성한 파일
- `src/lib/api/estimate/query.ts`

---

## 기타 참고 사항
- 각 페이지 이동 시 `page` 상태와 쿼리키 구분 주의 필요
