### PR TITLE
refactor: 프로필 페이지 기능 여러 개 추가/삭제/수정

### DIFF
--- a/src/app/[locale]/(with-protected)/profile/create/page.tsx
+++ b/src/app/[locale]/(with-protected)/profile/create/page.tsx
@@ -5,19 +5,36 @@ import { useAuth } from "@/context/AuthContext";
 import ClientProfileTitle from "@/components/domain/profile/ClientProfileTitle";
 import ClientProfilePostForm from "@/components/domain/profile/ClientProfilePostForm";
 import MoverProfilePostForm from "@/components/domain/profile/MoverProfilePostForms";
+import { useState } from "react";
+import ToastPopup from "@/components/common/ToastPopup";
 
 export default function CreateProfilePage() {
    const { user } = useAuth();
+   const [toast, setToast] = useState<{
+      id: number;
+      text: string;
+      success: boolean;
+   } | null>(null);
 
    // ✅ 일반으로 로그인한 회원의 경우
    if (user?.userType === "client") {
       return (
-         <div className="pt-4 pb-10 lg:pt-6">
-            <div className="mx-auto max-w-82 lg:max-w-160">
-               <ClientProfileTitle type="생성" />
-               <ClientProfilePostForm />
+         <>
+            <div className="pt-4 pb-10 lg:pt-6">
+               <div className="mx-auto max-w-82 lg:max-w-160">
+                  <ClientProfileTitle type="생성" />
+                  <ClientProfilePostForm setToast={setToast} />
+               </div>
             </div>
-         </div>
+
+            {toast && (
+               <ToastPopup
+                  key={toast.id}
+                  text={toast.text}
+                  success={toast.success}
+               />
+            )}
+         </>
       );
    }
 

--- a/src/app/[locale]/(with-protected)/profile/edit/page.tsx
+++ b/src/app/[locale]/(with-protected)/profile/edit/page.tsx
@@ -17,7 +17,6 @@ export default function EditProfilePage() {
 
    // ✅ 일반으로 로그인한 회원의 경우
    if (user?.userType === "client") {
-      console.log("toast 값:", toast);
       return (
          <>
             <div className="pt-4 pb-10 lg:pt-6">

--- a/src/app/[locale]/(with-protected)/profile/edit/page.tsx
+++ b/src/app/[locale]/(with-protected)/profile/edit/page.tsx
@@ -1,28 +1,45 @@
 "use client";
 
+import ToastPopup from "@/components/common/ToastPopup";
 import ClientProfileTitle from "@/components/domain/profile/ClientProfileTitle";
 import ClientProfileUpdateForm from "@/components/domain/profile/ClientProfileUpdateForm";
 import MoverProfileUpdateForm from "@/components/domain/profile/MoverProfileUpdateForms";
 import { useAuth } from "@/context/AuthContext";
+import { useState } from "react";
 
 export default function EditProfilePage() {
    const { user } = useAuth();
+   const [toast, setToast] = useState<{
+      id: number;
+      text: string;
+      success: boolean;
+   } | null>(null);
 
    // ✅ 일반으로 로그인한 회원의 경우
    if (user?.userType === "client") {
+      console.log("toast 값:", toast);
       return (
-         <div className="pt-4 pb-10 lg:pt-6">
-            <div
-               className={
-                  user?.provider === "LOCAL"
-                     ? "mx-auto max-w-82 lg:max-w-338"
-                     : "mx-auto max-w-82 lg:max-w-200"
-               }
-            >
-               <ClientProfileTitle type="수정" />
-               <ClientProfileUpdateForm />
+         <>
+            <div className="pt-4 pb-10 lg:pt-6">
+               <div
+                  className={
+                     user?.provider === "LOCAL"
+                        ? "mx-auto max-w-82 lg:max-w-338"
+                        : "mx-auto max-w-82 lg:max-w-200"
+                  }
+               >
+                  <ClientProfileTitle type="수정" />
+                  <ClientProfileUpdateForm setToast={setToast} />
+               </div>
             </div>
-         </div>
+            {toast && (
+               <ToastPopup
+                  key={toast.id}
+                  text={toast.text}
+                  success={toast.success}
+               />
+            )}
+         </>
       );
    }
 

--- a/src/components/domain/profile/ClientProfilePostForm.tsx
+++ b/src/components/domain/profile/ClientProfilePostForm.tsx
@@ -7,8 +7,9 @@ import SolidButton from "../../common/SolidButton";
 import { MOVE_TYPES, moveType, regions } from "@/constants";
 import useClientProfilePostForm from "@/lib/hooks/useClientProfilePostForm";
 import ImageInputField from "./ImageInputField";
+import { NotiSetting } from "@/lib/types";
 
-export default function ClientProfilePostForm() {
+export default function ClientProfilePostForm({ setToast }: NotiSetting) {
    // ✅ 함수 등 모음
    const {
       isValid,
@@ -20,10 +21,10 @@ export default function ClientProfilePostForm() {
       control,
       errors,
       watch,
-   } = useClientProfilePostForm();
+   } = useClientProfilePostForm({ setToast });
 
    return (
-      <form>
+      <form onSubmit={handleSubmit(onSubmit)}>
          {/* ✅ 이미지 */}
          <ImageInputField
             name="profileImage"
@@ -84,10 +85,7 @@ export default function ClientProfilePostForm() {
          </section>
 
          {/* ✅ 제출 버튼 */}
-         <SolidButton
-            disabled={!isValid || isLoading}
-            onClick={handleSubmit(onSubmit)}
-         >
+         <SolidButton type="submit" disabled={!isValid || isLoading}>
             {isLoading ? "로딩 중..." : "시작하기"}
          </SolidButton>
       </form>

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -59,14 +59,15 @@ export default function ClientProfileUpdateForm() {
                         : `${borderStyle} lg:w-full`
                   }
                />
-               <ProfileInput<ClientProfileUpdateValue>
-                  type="email"
-                  label="이메일"
-                  name="email"
-                  placeholder="codeit@email.com"
-                  register={register}
-                  error={errors.email?.message}
-               />
+               {/* 이메일은 변경할 수 있는 데이터가 아님 */}
+               <section className="flex w-full cursor-not-allowed flex-col gap-2 lg:gap-4">
+                  <label className="text-black-300 text-16-semibold lg:text-20-semibold">
+                     이메일
+                  </label>
+                  <div className="text-black-400 bg-bg-200 flex h-14 items-center rounded-2xl p-3.5 lg:h-16">
+                     {user?.email}
+                  </div>
+               </section>
                <hr
                   className={
                      user?.provider === "LOCAL"

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -12,11 +12,12 @@ import OutlinedButton from "@/components/common/OutlinedButton";
 import ImageInputField from "./ImageInputField";
 import { useAuth } from "@/context/AuthContext";
 import { ClientProfileUpdateValue } from "@/lib/schemas";
+import { NotiSetting } from "@/lib/types";
 
 const style1 = "lg:mb-14 lg:flex-row lg:justify-between lg:gap-14";
 const borderStyle = "border-line-100 my-5 lg:my-8";
 
-export default function ClientProfileUpdateForm() {
+export default function ClientProfileUpdateForm({ setToast }: NotiSetting) {
    // ✅ 함수 등 모음
    const { user } = useAuth();
    const {
@@ -31,207 +32,209 @@ export default function ClientProfileUpdateForm() {
       watch,
       control,
       handleCancel,
-   } = useClientProfileUpdateForm();
+   } = useClientProfileUpdateForm({ setToast });
 
    return (
-      <form onSubmit={handleSubmit(onSubmit)}>
-         <div
-            className={
-               user?.provider === "LOCAL"
-                  ? `flex flex-col ${style1}`
-                  : "flex flex-col"
-            }
-         >
-            {/* ✅ 입력창 모음 */}
-            <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
-               <ProfileInput<ClientProfileUpdateValue>
-                  type="text"
-                  label="이름"
-                  name="name"
-                  placeholder="김코드"
-                  register={register}
-                  error={errors.name?.message}
-               />
-               <hr
-                  className={
-                     user?.provider === "LOCAL"
-                        ? `${borderStyle} lg:w-160`
-                        : `${borderStyle} lg:w-full`
-                  }
-               />
-               {/* 이메일은 변경할 수 있는 데이터가 아님 */}
-               <section className="flex w-full cursor-not-allowed flex-col gap-2 lg:gap-4">
-                  <label className="text-black-300 text-16-semibold lg:text-20-semibold">
-                     이메일
-                  </label>
-                  <div className="text-black-400 bg-bg-200 flex h-14 items-center rounded-2xl p-3.5 lg:h-16">
-                     {user?.email}
-                  </div>
-               </section>
-               <hr
-                  className={
-                     user?.provider === "LOCAL"
-                        ? `${borderStyle} lg:w-160`
-                        : `${borderStyle} lg:w-full`
-                  }
-               />
-               <ProfileInput<ClientProfileUpdateValue>
-                  type="text"
-                  label="전화번호"
-                  name="phone"
-                  placeholder="숫자만 입력해 주세요."
-                  register={register}
-                  error={errors.phone?.message}
-               />
-               <hr
-                  className={
-                     user?.provider === "LOCAL"
-                        ? `${borderStyle} lg:w-160`
-                        : `${borderStyle} lg:w-full`
-                  }
-               />
-
-               {/* 비밀번호 관련 항목들 : 소셜 로그인 하면 화면에 안 나옴 */}
-               {user && user.provider !== "LOCAL" ? null : (
-                  <>
-                     <ProfilePasswordInput<ClientProfileUpdateValue>
-                        label="현재 비밀번호"
-                        name="password"
-                        placeholder="현재 비밀번호를 입력해 주세요."
-                        register={register}
-                        error={errors.password?.message}
-                     />
-                     <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
-                     <ProfilePasswordInput<ClientProfileUpdateValue>
-                        label="새 비밀번호"
-                        name="newPassword"
-                        placeholder="새로운 비밀번호를 입력해 주세요."
-                        register={register}
-                        error={errors.newPassword?.message}
-                     />
-                     <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
-                     <ProfilePasswordInput<ClientProfileUpdateValue>
-                        label="새 비밀번호"
-                        name="newPassword"
-                        placeholder="새로운 비밀번호를 다시 한번 입력해 주세요."
-                        register={register}
-                        error={errors.newPassword?.message}
-                     />
-                     <hr className="border-line-100 my-5 lg:my-8 lg:hidden" />
-                  </>
-               )}
-            </div>
-
-            <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
-               {/* ✅ 프로필 이미지 */}
-               <ImageInputField
-                  name="profileImage"
-                  text="프로필 이미지"
-                  control={control}
-               />
-
-               <hr
-                  className={
-                     user?.provider === "LOCAL"
-                        ? `${borderStyle} lg:w-160`
-                        : `${borderStyle} lg:w-full`
-                  }
-               />
-
-               {/* ✅ 이용 서비스 */}
-               <section>
-                  <ClientProfileTitle
-                     type="서비스"
-                     error={errors.serviceType?.message}
-                  />
-
-                  {moveType.map((service) => {
-                     const value =
-                        MOVE_TYPES[service as keyof typeof MOVE_TYPES]; // "소형이사" → "SMALL"
-
-                     return (
-                        <ProfileFieldButton
-                           category="서비스"
-                           name="serviceType"
-                           key={service}
-                           value={service}
-                           isSelected={(watch("serviceType") || []).includes(
-                              value,
-                           )}
-                           onClick={() => handleServiceToggle(value)}
-                        >
-                           {service}
-                        </ProfileFieldButton>
-                     );
-                  })}
-               </section>
-
-               <hr
-                  className={
-                     user?.provider === "LOCAL"
-                        ? `${borderStyle} lg:w-160`
-                        : `${borderStyle} lg:w-full`
-                  }
-               />
-
-               {/* ✅ 내가 사는 지역 */}
-               <section className="mb-8 lg:mb-14">
-                  <ClientProfileTitle
-                     type="지역"
-                     error={errors.livingArea?.message}
-                  />
-
-                  <div className="grid w-70 grid-cols-5 gap-x-2 gap-y-3 lg:w-104 lg:gap-x-3.5 lg:gap-y-4.5">
-                     {regions.map((region) => (
-                        <ProfileFieldButton
-                           category="지역"
-                           name="livingArea"
-                           key={region}
-                           value={region}
-                           isSelected={(watch("livingArea") || []).includes(
-                              region,
-                           )}
-                           onClick={() => handleRegionToggle(region)}
-                        >
-                           {region}
-                        </ProfileFieldButton>
-                     ))}
-                  </div>
-               </section>
-            </div>
-         </div>
-
-         {/* ✅ 제출 버튼 */}
-         <section
-            className={
-               user?.provider === "LOCAL"
-                  ? "flex w-full flex-col gap-2 lg:flex-row lg:justify-between lg:gap-4"
-                  : "flex w-full flex-col gap-2"
-            }
-         >
-            <SolidButton
-               type="submit"
-               disabled={isLoading || !isValid}
+      <>
+         <form onSubmit={handleSubmit(onSubmit)}>
+            <div
                className={
                   user?.provider === "LOCAL"
-                     ? "max-w-165 lg:w-auto lg:flex-1"
-                     : ""
+                     ? `flex flex-col ${style1}`
+                     : "flex flex-col"
                }
             >
-               {isLoading ? "로딩 중..." : "수정하기"}
-            </SolidButton>
-            <OutlinedButton
-               type="button"
-               onClick={handleCancel}
+               {/* ✅ 입력창 모음 */}
+               <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
+                  <ProfileInput<ClientProfileUpdateValue>
+                     type="text"
+                     label="이름"
+                     name="name"
+                     placeholder="김코드"
+                     register={register}
+                     error={errors.name?.message}
+                  />
+                  <hr
+                     className={
+                        user?.provider === "LOCAL"
+                           ? `${borderStyle} lg:w-160`
+                           : `${borderStyle} lg:w-full`
+                     }
+                  />
+                  {/* 이메일은 변경할 수 있는 데이터가 아님 */}
+                  <section className="flex w-full cursor-not-allowed flex-col gap-2 lg:gap-4">
+                     <label className="text-black-300 text-16-semibold lg:text-20-semibold">
+                        이메일
+                     </label>
+                     <div className="text-black-400 bg-bg-200 flex h-14 items-center rounded-2xl p-3.5 lg:h-16">
+                        {user?.email}
+                     </div>
+                  </section>
+                  <hr
+                     className={
+                        user?.provider === "LOCAL"
+                           ? `${borderStyle} lg:w-160`
+                           : `${borderStyle} lg:w-full`
+                     }
+                  />
+                  <ProfileInput<ClientProfileUpdateValue>
+                     type="text"
+                     label="전화번호"
+                     name="phone"
+                     placeholder="숫자만 입력해 주세요."
+                     register={register}
+                     error={errors.phone?.message}
+                  />
+                  <hr
+                     className={
+                        user?.provider === "LOCAL"
+                           ? `${borderStyle} lg:w-160`
+                           : `${borderStyle} lg:w-full`
+                     }
+                  />
+
+                  {/* 비밀번호 관련 항목들 : 소셜 로그인 하면 화면에 안 나옴 */}
+                  {user && user.provider !== "LOCAL" ? null : (
+                     <>
+                        <ProfilePasswordInput<ClientProfileUpdateValue>
+                           label="현재 비밀번호"
+                           name="password"
+                           placeholder="현재 비밀번호를 입력해 주세요."
+                           register={register}
+                           error={errors.password?.message}
+                        />
+                        <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+                        <ProfilePasswordInput<ClientProfileUpdateValue>
+                           label="새 비밀번호"
+                           name="newPassword"
+                           placeholder="새로운 비밀번호를 입력해 주세요."
+                           register={register}
+                           error={errors.newPassword?.message}
+                        />
+                        <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+                        <ProfilePasswordInput<ClientProfileUpdateValue>
+                           label="새 비밀번호"
+                           name="newPassword"
+                           placeholder="새로운 비밀번호를 다시 한번 입력해 주세요."
+                           register={register}
+                           error={errors.newPassword?.message}
+                        />
+                        <hr className="border-line-100 my-5 lg:my-8 lg:hidden" />
+                     </>
+                  )}
+               </div>
+
+               <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
+                  {/* ✅ 프로필 이미지 */}
+                  <ImageInputField
+                     name="profileImage"
+                     text="프로필 이미지"
+                     control={control}
+                  />
+
+                  <hr
+                     className={
+                        user?.provider === "LOCAL"
+                           ? `${borderStyle} lg:w-160`
+                           : `${borderStyle} lg:w-full`
+                     }
+                  />
+
+                  {/* ✅ 이용 서비스 */}
+                  <section>
+                     <ClientProfileTitle
+                        type="서비스"
+                        error={errors.serviceType?.message}
+                     />
+
+                     {moveType.map((service) => {
+                        const value =
+                           MOVE_TYPES[service as keyof typeof MOVE_TYPES]; // "소형이사" → "SMALL"
+
+                        return (
+                           <ProfileFieldButton
+                              category="서비스"
+                              name="serviceType"
+                              key={service}
+                              value={service}
+                              isSelected={(watch("serviceType") || []).includes(
+                                 value,
+                              )}
+                              onClick={() => handleServiceToggle(value)}
+                           >
+                              {service}
+                           </ProfileFieldButton>
+                        );
+                     })}
+                  </section>
+
+                  <hr
+                     className={
+                        user?.provider === "LOCAL"
+                           ? `${borderStyle} lg:w-160`
+                           : `${borderStyle} lg:w-full`
+                     }
+                  />
+
+                  {/* ✅ 내가 사는 지역 */}
+                  <section className="mb-8 lg:mb-14">
+                     <ClientProfileTitle
+                        type="지역"
+                        error={errors.livingArea?.message}
+                     />
+
+                     <div className="grid w-70 grid-cols-5 gap-x-2 gap-y-3 lg:w-104 lg:gap-x-3.5 lg:gap-y-4.5">
+                        {regions.map((region) => (
+                           <ProfileFieldButton
+                              category="지역"
+                              name="livingArea"
+                              key={region}
+                              value={region}
+                              isSelected={(watch("livingArea") || []).includes(
+                                 region,
+                              )}
+                              onClick={() => handleRegionToggle(region)}
+                           >
+                              {region}
+                           </ProfileFieldButton>
+                        ))}
+                     </div>
+                  </section>
+               </div>
+            </div>
+
+            {/* ✅ 제출 버튼 */}
+            <section
                className={
                   user?.provider === "LOCAL"
-                     ? "max-w-165 !border-gray-200 !text-gray-200 lg:w-auto lg:flex-1"
-                     : "!border-gray-200 !text-gray-200"
+                     ? "flex w-full flex-col gap-2 lg:flex-row lg:justify-between lg:gap-4"
+                     : "flex w-full flex-col gap-2"
                }
             >
-               취소
-            </OutlinedButton>
-         </section>
-      </form>
+               <SolidButton
+                  type="submit"
+                  disabled={isLoading || !isValid}
+                  className={
+                     user?.provider === "LOCAL"
+                        ? "max-w-165 lg:w-auto lg:flex-1"
+                        : ""
+                  }
+               >
+                  {isLoading ? "로딩 중..." : "수정하기"}
+               </SolidButton>
+               <OutlinedButton
+                  type="button"
+                  onClick={handleCancel}
+                  className={
+                     user?.provider === "LOCAL"
+                        ? "max-w-165 !border-gray-200 !text-gray-200 lg:w-auto lg:flex-1"
+                        : "!border-gray-200 !text-gray-200"
+                  }
+               >
+                  취소
+               </OutlinedButton>
+            </section>
+         </form>
+      </>
    );
 }

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -89,44 +89,37 @@ export default function ClientProfileUpdateForm() {
                         : `${borderStyle} lg:w-full`
                   }
                />
-               {user && user.provider === "LOCAL" && (
-                  <ProfilePasswordInput<ClientProfileUpdateValue>
-                     label="현재 비밀번호"
-                     name="password"
-                     placeholder="현재 비밀번호를 입력해 주세요."
-                     register={register}
-                     error={errors.password?.message}
-                  />
-               )}
-               {user && user.provider === "LOCAL" && (
-                  <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
-               )}
-               {user && user.provider === "LOCAL" && (
-                  <ProfilePasswordInput<ClientProfileUpdateValue>
-                     label="새 비밀번호"
-                     name="newPassword"
-                     placeholder="현재 비밀번호를 입력해 주세요."
-                     register={register}
-                     error={errors.newPassword?.message}
-                  />
-               )}
-               {user && user.provider === "LOCAL" && (
-                  <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
-               )}
-               {user && user.provider === "LOCAL" && (
-                  <ProfilePasswordInput<ClientProfileUpdateValue>
-                     label="새 비밀번호 확인"
-                     name="newPasswordConfirmation"
-                     placeholder="새 비밀번호를 다시 한번 입력해 주세요."
-                     register={register}
-                     error={errors.newPasswordConfirmation?.message}
-                  />
+
+               {/* 비밀번호 관련 항목들 : 소셜 로그인 하면 화면에 안 나옴 */}
+               {user && user.provider !== "LOCAL" ? null : (
+                  <>
+                     <ProfilePasswordInput<ClientProfileUpdateValue>
+                        label="현재 비밀번호"
+                        name="password"
+                        placeholder="현재 비밀번호를 입력해 주세요."
+                        register={register}
+                        error={errors.password?.message}
+                     />
+                     <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+                     <ProfilePasswordInput<ClientProfileUpdateValue>
+                        label="새 비밀번호"
+                        name="newPassword"
+                        placeholder="새로운 비밀번호를 입력해 주세요."
+                        register={register}
+                        error={errors.newPassword?.message}
+                     />
+                     <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
+                     <ProfilePasswordInput<ClientProfileUpdateValue>
+                        label="새 비밀번호"
+                        name="newPassword"
+                        placeholder="새로운 비밀번호를 다시 한번 입력해 주세요."
+                        register={register}
+                        error={errors.newPassword?.message}
+                     />
+                     <hr className="border-line-100 my-5 lg:my-8 lg:hidden" />
+                  </>
                )}
             </div>
-
-            {user && user.provider === "LOCAL" && (
-               <hr className="border-line-100 my-5 lg:my-8 lg:hidden" />
-            )}
 
             <div className={user?.provider === "LOCAL" ? "flex-1" : ""}>
                {/* ✅ 프로필 이미지 */}

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -13,12 +13,14 @@ import ImageInputField from "./ImageInputField";
 import { useAuth } from "@/context/AuthContext";
 import { ClientProfileUpdateValue } from "@/lib/schemas";
 import { NotiSetting } from "@/lib/types";
+import { useRouter } from "next/navigation";
 
 const style1 = "lg:mb-14 lg:flex-row lg:justify-between lg:gap-14";
 const borderStyle = "border-line-100 my-5 lg:my-8";
 
 export default function ClientProfileUpdateForm({ setToast }: NotiSetting) {
    // ✅ 함수 등 모음
+   const router = useRouter();
    const { user } = useAuth();
    const {
       register,
@@ -31,7 +33,6 @@ export default function ClientProfileUpdateForm({ setToast }: NotiSetting) {
       handleSubmit,
       watch,
       control,
-      handleCancel,
    } = useClientProfileUpdateForm({ setToast });
 
    return (
@@ -223,8 +224,7 @@ export default function ClientProfileUpdateForm({ setToast }: NotiSetting) {
                   {isLoading ? "로딩 중..." : "수정하기"}
                </SolidButton>
                <OutlinedButton
-                  type="button"
-                  onClick={handleCancel}
+                  onClick={() => router.push("/mover-search")}
                   className={
                      user?.provider === "LOCAL"
                         ? "max-w-165 !border-gray-200 !text-gray-200 lg:w-auto lg:flex-1"

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -62,7 +62,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       try {
          await delay(200);
-
          const response = await authApi.getMe();
 
          if (response?.user) setUser(response.user);

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -8,11 +8,11 @@ import { ClientProfilePostSchema, ClientProfilePostValue } from "../schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import updateProfileImage from "../api/auth/requests/updateProfileImage";
 import { AuthFetchError } from "../types";
-import { ServiceType } from "../types/client.types";
+import { NotiSetting, ServiceType } from "../types/client.types";
 import clientProfile from "../api/auth/requests/updateClientProfile";
 import { tokenSettings } from "../utils";
 
-export default function useClientProfilePostForm() {
+export default function useClientProfilePostForm({ setToast }: NotiSetting) {
    // ✅ 상태 모음
    const router = useRouter();
    const [isLoading, setIsLoading] = useState(false);
@@ -86,11 +86,22 @@ export default function useClientProfilePostForm() {
                tokenSettings.set(res.data.accessToken);
             }
 
-            setUser(res.data);
-            await refreshUser(); // 프로필 수정 페이지에서  첫 로그인 시 지역 정보를 바로 못 받아서 넣음
-            setTimeout(() => {
-               router.replace("/mover-search");
-            }, 100);
+            // 알림
+            setToast({
+               id: Date.now(),
+               text: "프로필이 등록되었습니다.",
+               success: true,
+            });
+
+            // setUser(res.data);
+
+            // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
+            setTimeout(async () => {
+               await refreshUser();
+               setTimeout(() => {
+                  router.replace("/mover-search");
+               }, 100);
+            }, 1500);
          }
       } catch (error) {
          console.error("일반 프로필 등록 실패: ", error);

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -16,7 +16,7 @@ export default function useClientProfilePostForm() {
    // ✅ 상태 모음
    const router = useRouter();
    const [isLoading, setIsLoading] = useState(false);
-   const { setUser } = useAuth();
+   const { setUser, refreshUser } = useAuth();
 
    // react-hook-form
    const {
@@ -87,8 +87,7 @@ export default function useClientProfilePostForm() {
             }
 
             setUser(res.data);
-            // alert("프로필이 등록되었습니다.");
-            // user 상태 갱신: 미들웨어가 인식할 시간을 줌
+            await refreshUser(); // 프로필 수정 페이지에서  첫 로그인 시 지역 정보를 바로 못 받아서 넣음
             setTimeout(() => {
                router.replace("/mover-search");
             }, 100);

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -93,8 +93,6 @@ export default function useClientProfilePostForm({ setToast }: NotiSetting) {
                success: true,
             });
 
-            // setUser(res.data);
-
             // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
             setTimeout(async () => {
                await refreshUser();

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -16,7 +16,7 @@ export default function useClientProfilePostForm({ setToast }: NotiSetting) {
    // ✅ 상태 모음
    const router = useRouter();
    const [isLoading, setIsLoading] = useState(false);
-   const { setUser, refreshUser } = useAuth();
+   const { refreshUser } = useAuth();
 
    // react-hook-form
    const {

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -11,10 +11,10 @@ import {
    updateClientProfileSchema,
 } from "../schemas";
 import clientProfile from "../api/auth/requests/updateClientProfile";
-import { ServiceType } from "../types/client.types";
+import { NotiSetting, ServiceType } from "../types/client.types";
 import updateProfileImage from "../api/auth/requests/updateProfileImage";
 
-export default function useClientProfileUpdateForm() {
+export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
    // ✅ 상태 모음
    const router = useRouter();
    const { user, refreshUser } = useAuth();
@@ -118,16 +118,24 @@ export default function useClientProfileUpdateForm() {
             serviceType: watch("serviceType") || [],
             livingArea: watch("livingArea") || [],
          };
-
          await clientProfile.update(payload);
-         alert("프로필이 수정되었습니다.");
 
+         setToast({
+            id: Date.now(),
+            text: "프로필이 수정되었습니다.",
+            success: true,
+         });
          // user 상태 즉각 반영
-         if (refreshUser) {
+         // 알림창
+         setTimeout(async () => {
             await refreshUser();
-         }
-
-         router.replace("/mover-search");
+            setTimeout(() => {
+               router.replace("/mover-search");
+            }, 500);
+         }, 1500);
+         // setTimeout(() => {
+         //    router.replace("/mover-search");
+         // }, 1000);
       } catch (error) {
          console.error("일반 프로필 수정 실패: ", error);
 

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -88,11 +88,6 @@ export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
       reset(initialValues);
    }, [initialValues, reset]);
 
-   // ✅ 기본값 초기화 설정333 = 이름 등을 보존하려면 현재 값 기준으로 써야 함 (취소 버튼으로 연결)
-   const handleCancel = () => {
-      reset(initialValues);
-   };
-
    // ✅ api 호출하고 프로필 생성 성공하면 mover-search로 이동: 이미지 부분 수정해야 함
    const onSubmit = async (data: ClientProfileUpdateValue) => {
       setIsLoading(true);
@@ -166,6 +161,5 @@ export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
       handleSubmit,
       watch,
       control,
-      handleCancel,
    };
 }

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -118,6 +118,7 @@ export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
             serviceType: watch("serviceType") || [],
             livingArea: watch("livingArea") || [],
          };
+
          await clientProfile.update(payload);
 
          setToast({
@@ -125,17 +126,14 @@ export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
             text: "프로필이 수정되었습니다.",
             success: true,
          });
-         // user 상태 즉각 반영
-         // 알림창
+
+         // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
          setTimeout(async () => {
             await refreshUser();
             setTimeout(() => {
                router.replace("/mover-search");
             }, 500);
          }, 1500);
-         // setTimeout(() => {
-         //    router.replace("/mover-search");
-         // }, 1000);
       } catch (error) {
          console.error("일반 프로필 수정 실패: ", error);
 

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -27,7 +27,6 @@ export default function useClientProfileUpdateForm() {
 
          return {
             name: client.name ?? "",
-            email: client.email ?? "",
             phone: client.phone ?? "",
             profileImage: client.profileImage ?? "",
             serviceType: client.serviceType ?? [],
@@ -37,7 +36,6 @@ export default function useClientProfileUpdateForm() {
 
       return {
          name: "",
-         email: "",
          phone: "",
          profileImage: "",
          serviceType: [],

--- a/src/lib/schemas/client.schema.ts
+++ b/src/lib/schemas/client.schema.ts
@@ -17,15 +17,20 @@ export const livingAreaSchema = z
 
 const passwordSchema = z.string().optional();
 
+// ✅ 일반 프로필 등록 스키마
+export const ClientProfilePostSchema = z.object({
+   profileImage: profileImageSchema,
+   serviceType: serviceTypeSchema,
+   livingArea: livingAreaSchema,
+});
+
 /**
- * 함수로 제작
+ * ✅ 일반 프로필 수정 스키마: 함수로 제작
  */
 export function updateClientProfileSchema(provider?: string) {
-   // ✅ 일반 프로필 수정 스키마
    return z
       .object({
          name: nameSchema.optional(),
-         email: emailSchema.optional(),
          phone: phoneSchema.optional(),
          password: passwordSchema,
          newPassword: passwordSchema.or(z.literal("")),
@@ -41,7 +46,6 @@ export function updateClientProfileSchema(provider?: string) {
 
          // 0. [일반 로그인] 현재 비밀번호 필수
          if (provider === "LOCAL") {
-            // [로컬 로그인] 현재 비밀번호는 항상 필수
             if (!password || password.length === 0) {
                ctx.addIssue({
                   path: ["password"],
@@ -82,13 +86,6 @@ export function updateClientProfileSchema(provider?: string) {
          }
       });
 }
-
-// ✅ 일반 프로필 등록 스키마
-export const ClientProfilePostSchema = z.object({
-   profileImage: profileImageSchema,
-   serviceType: serviceTypeSchema,
-   livingArea: livingAreaSchema,
-});
 
 // ✅ 타입 반출
 export type ClientProfilePostValue = z.infer<typeof ClientProfilePostSchema>;

--- a/src/lib/schemas/client.schema.ts
+++ b/src/lib/schemas/client.schema.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { emailSchema, nameSchema, phoneSchema } from "./auth.schema";
+import { nameSchema, phoneSchema } from "./auth.schema";
 
 // ✅ 개별 스키마
 export const profileImageSchema = z

--- a/src/lib/types/client.types.ts
+++ b/src/lib/types/client.types.ts
@@ -20,3 +20,8 @@ export interface ClientProfileUpdateData<T extends FieldValues> {
    error?: string;
    social?: boolean;
 }
+
+// 토스트 알림
+export interface NotiSetting {
+   setToast: (toast: { id: number; text: string; success: boolean }) => void;
+}


### PR DESCRIPTION
## 작업 개요
- 프로필 페이지 기능 여러 개 추가/삭제/수정

---

## 작업 상세 내용
- [x] 코드 스타일 최적화 및 오류 수정
- [x] 프로필 수정 페이지에서 이메일 입력 불가능하게 재설정
- [x] 프로필 페이지 토스트 알림 기능 추가
- [ ] 회원 탈퇴 기능 - 헤더 프로필 드롭다운 메뉴에 넣을 예정

---

## 🗂️ 수정한 파일
- `src/app/[locale]/(with-protected)/profile/create/page.tsx`
- `src/app/[locale]/(with-protected)/profile/edit/page.tsx`
- `src/components/domain/profile/ClientProfilePostForm.tsx`
- `src/lib/hooks/useClientProfilePostForm.ts`
- `src/lib/hooks/useClientProfileUpdateForm.ts`
- `src/lib/schemas/client.schema.ts`
- `src/lib/types/client.types.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- 남은 작업도 마저 합니다.
