### PR TITLE
fix: 기사 견적 상세 페이지 오류 수정

### DIFF
--- a/src/components/domain/my-quotes/SentQuoteDetailContent.tsx
+++ b/src/components/domain/my-quotes/SentQuoteDetailContent.tsx
@@ -32,7 +32,7 @@ export default async function SentQuoteDetailContent({ id }: { id: string }) {
                   )}
                   <MoveChip type={request.moveType} />
                   <DesignatedBadge
-                     designatedRequest={request.designatedRequest}
+                     designatedRequest={request.designatedRequests}
                   />
                </div>
                <p className="text-16-semibold lg:text-20-semibold">


### PR DESCRIPTION
## 작업 개요
- [기사] 내 견적관리에서 상세 페이지 접근 오류 수정

---

## 작업 상세 내용
- [x] 백엔드 스키마 수정 사항 미반영으로 인한 오류

---

## 🗂️ 수정한 파일
- `src/components/domain/my-quotes/SentQuoteDetailContent.tsx`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x
