### PR TITLE
refactor: 보낸 견적 요청 페이지 무한스크롤, 정렬 드롭다운 적용

### DIFF
--- a/src/components/domain/my-quotes/Dropdown.tsx
+++ b/src/components/domain/my-quotes/Dropdown.tsx
@@ -1,43 +1,39 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import chervronDown from "@/assets/images/chevronDownIcon.svg";
+import { useOutsideClick } from "@/lib/hooks/useOutsideClick";
 
-interface Dropdown {
-   dropdownName: string;
-   setDropdownName: (name: string) => void;
+interface DropdownOption {
+   label: string;
+   value: string;
+}
+interface DropdownProps {
+   selectedValue: string;
+   setSelectedValue: (value: string) => void;
+   options: DropdownOption[];
 }
 
-export default function Dropdown({ dropdownName, setDropdownName }: Dropdown) {
+export default function Dropdown({
+   selectedValue,
+   setSelectedValue,
+   options,
+}: DropdownProps) {
    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
    const dropdownRef = useRef<HTMLDivElement>(null);
 
    // 드롭다운 외부 클릭 시 닫기
-   useEffect(() => {
-      const handleClickOutside = (event: MouseEvent) => {
-         if (
-            dropdownRef.current &&
-            !dropdownRef.current.contains(event.target as Node)
-         ) {
-            setIsDropdownOpen(false);
-         }
-      };
-
-      if (isDropdownOpen) {
-         document.addEventListener("mousedown", handleClickOutside);
-      }
-
-      return () => {
-         document.removeEventListener("mousedown", handleClickOutside);
-      };
-   }, [isDropdownOpen]);
+   useOutsideClick(dropdownRef, () => setIsDropdownOpen(false));
 
    // 드롭다운 항목 선택 시 닫기
-   const handleDropdownItemClick = (name: string) => {
-      setDropdownName(name);
+   const handleDropdownItemClick = (value: string) => {
+      setSelectedValue(value);
       setIsDropdownOpen(false);
    };
+
+   const selectedLabel =
+      options.find((opt) => opt.value === selectedValue)?.label || "";
 
    return (
       <aside className="relative w-31.5 lg:w-47.5" ref={dropdownRef}>
@@ -45,25 +41,20 @@ export default function Dropdown({ dropdownName, setDropdownName }: Dropdown) {
             onClick={() => setIsDropdownOpen((prev) => !prev)}
             className="border-line-100 bg-gray50 flex h-9 cursor-pointer items-center justify-between rounded-lg border px-3 py-1.5 lg:h-16 lg:rounded-2xl lg:px-6 lg:py-4"
          >
-            <p className="text-14-medium lg:text-18-medium">
-               {dropdownName === "all" ? "전체" : "확정된 견적"}
-            </p>
+            <p className="text-14-medium lg:text-18-medium">{selectedLabel}</p>
             <Image src={chervronDown} alt="카테고리" width={20} height={20} />
          </div>
          {isDropdownOpen && (
             <ul className="border-line-100 absolute w-full rounded-lg border bg-white">
-               <li
-                  onClick={() => handleDropdownItemClick("all")}
-                  className="text-14-medium lg:text-18-medium flex h-9 cursor-pointer items-center px-3.5 py-4 lg:h-16"
-               >
-                  전체
-               </li>
-               <li
-                  onClick={() => handleDropdownItemClick("confirmed")}
-                  className="text-14-medium lg:text-18-medium flex h-9 cursor-pointer items-center px-3.5 py-4 lg:h-16"
-               >
-                  확정한 견적서
-               </li>
+               {options.map((opt) => (
+                  <li
+                     key={opt.value}
+                     onClick={() => handleDropdownItemClick(opt.value)}
+                     className="text-14-medium lg:text-18-medium flex h-9 cursor-pointer items-center px-3.5 py-4 lg:h-16"
+                  >
+                     {opt.label}
+                  </li>
+               ))}
             </ul>
          )}
       </aside>

--- a/src/components/domain/my-quotes/Received.tsx
+++ b/src/components/domain/my-quotes/Received.tsx
@@ -63,14 +63,6 @@ export default function Received() {
 
    return (
       <div className="flex flex-col gap-2 md:gap-4 lg:gap-8">
-         <h2 className="text-18-semibold lg:text-24-semibold flex items-center justify-between md:mx-auto md:w-150 lg:w-350">
-            견적 요청 목록
-            <Dropdown
-               dropdownName={dropdownName}
-               setDropdownName={setDropdownName}
-            />
-         </h2>
-
          {groupedData.map(({ request, estimates }, idx) => (
             <section
                key={idx}

--- a/src/components/domain/my-quotes/Received.tsx
+++ b/src/components/domain/my-quotes/Received.tsx
@@ -80,8 +80,12 @@ export default function Received() {
                      견적서 목록
                   </p>
                   <Dropdown
-                     dropdownName={dropdownName}
-                     setDropdownName={setDropdownName}
+                     selectedValue={dropdownName}
+                     setSelectedValue={setDropdownName}
+                     options={[
+                        { label: "전체", value: "all" },
+                        { label: "확정한 견적서", value: "confirmed" },
+                     ]}
                   />
                </main>
                <main className="mt-4 flex flex-col gap-6 md:gap-8 lg:mt-8 lg:gap-14">

--- a/src/lib/api/estimate/query.ts
+++ b/src/lib/api/estimate/query.ts
@@ -3,6 +3,7 @@ import { getRejectedEstimates } from "./requests/getRejectedEstimates";
 import { getSentEstimates } from "./requests/getSentEstimates";
 import { fetchClientPendingQuotes } from "./getClientPendingQuote";
 import { fetchClientReceivedQuotes } from "./getClientReceivedQuote";
+import { getRequests } from "./requests/getClientRequest";
 
 export function useRejectedEstimates(page: number) {
    return useQuery({
@@ -54,5 +55,14 @@ export function useReceivedEstimates(category: string) {
          return undefined;
       },
       initialPageParam: 1,
+   });
+}
+
+export function useRequestsQuery(sort: "asc" | "desc") {
+   return useInfiniteQuery({
+      queryKey: ["requests", sort],
+      queryFn: ({ pageParam }) => getRequests({ cursor: pageParam, sort }),
+      initialPageParam: undefined,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
    });
 }

--- a/src/lib/api/estimate/requests/getClientRequest.ts
+++ b/src/lib/api/estimate/requests/getClientRequest.ts
@@ -1,13 +1,17 @@
 import { tokenFetch } from "@/lib/utils/fetch-client";
-
-export async function getClientActiveRequest() {
-   return await tokenFetch("/requests/client/active", {
-      method: "GET",
-   });
+interface PageParms {
+   cursor?: string;
+   sort?: "asc" | "desc";
 }
 
-export async function getRequests() {
-   return await tokenFetch("/requests/client", {
-      method: "GET",
-   });
+export async function getClientActiveRequest() {
+   return await tokenFetch("/requests/client/active");
+}
+
+export async function getRequests({ cursor, sort }: PageParms) {
+   const queryParams = new URLSearchParams();
+   queryParams.append("sort", sort as string);
+   if (cursor) queryParams.append("cursor", cursor);
+
+   return await tokenFetch(`/requests/client?${queryParams.toString()}`);
 }


### PR DESCRIPTION
## 작업 개요
- 보낸 견적 요청 페이지 무한스크롤, 정렬 드롭다운 적용

---

## 작업 상세 내용
- [x] 기존 fetch 요청 -> `useInfiniteQuery` 사용하여 무한스크롤로 변경
- [x] 받은 요청 페이지 드롭다운 컴포넌트 변형하여 정렬 기능 추가

---

## 🗂️ 수정한 파일
- `src/lib/api/estimate/requests/getClientRequest.ts`
- `src/lib/api/estimate/query.ts`
- `src/components/domain/my-quotes/Requested.tsx`
- `src/components/domain/my-quotes/Dropdown.tsx`
- `src/components/domain/my-quotes/Received.tsx` -> 수정한 드롭다운 컴포넌트에 맞게 props 수정

---

## 🗂️ 새로 작성한 파일
- x

---

## 스크린샷
<img width="708" height="206" alt="image" src="https://github.com/user-attachments/assets/cf8ce3fd-ac6b-42c4-a5f2-ceaed283e65b" />
