### PR TITLE
feat: 토스트 알림 전역화 외

### DIFF
--- a/src/app/[locale]/(with-guest)/sign-in/client/page.tsx
+++ b/src/app/[locale]/(with-guest)/sign-in/client/page.tsx
@@ -1,8 +1,13 @@
+"use client";
+
 import ClientTitle from "@/components/domain/auth/ClientTitle";
 import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
 import SignInForm from "@/components/domain/auth/SignInForm";
+import { useAuthError } from "@/lib/hooks/useAuthError";
 
 export default function ClientSignInPage() {
+   useAuthError();
+
    return (
       <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
          {/* 제목 + 기사 페이지로 링크 이동 */}

--- a/src/app/[locale]/(with-guest)/sign-in/mover/page.tsx
+++ b/src/app/[locale]/(with-guest)/sign-in/mover/page.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
 import MoverTitle from "@/components/domain/auth/MoverTitle";
 import SignInForm from "@/components/domain/auth/SignInForm";
+import { useAuthError } from "@/lib/hooks/useAuthError";
 
+//
 export default function MoverSignInPage() {
+   useAuthError();
+
    return (
       <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
          {/* 제목 + 일반유저 페이지로 링크 이동 */}

--- a/src/app/[locale]/(with-guest)/sign-up/client/page.tsx
+++ b/src/app/[locale]/(with-guest)/sign-up/client/page.tsx
@@ -1,8 +1,11 @@
 import SignUpForm from "@/components/domain/auth/SignUpForm";
 import ClientTitle from "@/components/domain/auth/ClientTitle";
 import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
+import { useAuthError } from "@/lib/hooks/useAuthError";
 
 export default function ClientSignUpPage() {
+   useAuthError();
+
    return (
       <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
          {/* 제목 + 기사 페이지로 링크 이동 */}

--- a/src/app/[locale]/(with-guest)/sign-up/client/page.tsx
+++ b/src/app/[locale]/(with-guest)/sign-up/client/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import SignUpForm from "@/components/domain/auth/SignUpForm";
 import ClientTitle from "@/components/domain/auth/ClientTitle";
 import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";

--- a/src/app/[locale]/(with-guest)/sign-up/mover/page.tsx
+++ b/src/app/[locale]/(with-guest)/sign-up/mover/page.tsx
@@ -1,8 +1,11 @@
 import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
 import MoverTitle from "@/components/domain/auth/MoverTitle";
 import SignUpForm from "@/components/domain/auth/SignUpForm";
+import { useAuthError } from "@/lib/hooks/useAuthError";
 
 export default function MoverSignUpPage() {
+   useAuthError();
+
    return (
       <section className="mx-auto mt-18 mb-31 flex w-82 flex-col items-center lg:w-160">
          {/* 제목 + 기사 페이지로 링크 이동 */}

--- a/src/app/[locale]/(with-guest)/sign-up/mover/page.tsx
+++ b/src/app/[locale]/(with-guest)/sign-up/mover/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import EasyLoginForm from "@/components/domain/auth/EasyLoginForm";
 import MoverTitle from "@/components/domain/auth/MoverTitle";
 import SignUpForm from "@/components/domain/auth/SignUpForm";

--- a/src/app/[locale]/(with-protected)/profile/create/page.tsx
+++ b/src/app/[locale]/(with-protected)/profile/create/page.tsx
@@ -5,16 +5,9 @@ import { useAuth } from "@/context/AuthContext";
 import ClientProfileTitle from "@/components/domain/profile/ClientProfileTitle";
 import ClientProfilePostForm from "@/components/domain/profile/ClientProfilePostForm";
 import MoverProfilePostForm from "@/components/domain/profile/MoverProfilePostForms";
-import { useState } from "react";
-import ToastPopup from "@/components/common/ToastPopup";
 
 export default function CreateProfilePage() {
    const { user } = useAuth();
-   const [toast, setToast] = useState<{
-      id: number;
-      text: string;
-      success: boolean;
-   } | null>(null);
 
    // ✅ 일반으로 로그인한 회원의 경우
    if (user?.userType === "client") {
@@ -23,17 +16,9 @@ export default function CreateProfilePage() {
             <div className="pt-4 pb-10 lg:pt-6">
                <div className="mx-auto max-w-82 lg:max-w-160">
                   <ClientProfileTitle type="생성" />
-                  <ClientProfilePostForm setToast={setToast} />
+                  <ClientProfilePostForm />
                </div>
             </div>
-
-            {toast && (
-               <ToastPopup
-                  key={toast.id}
-                  text={toast.text}
-                  success={toast.success}
-               />
-            )}
          </>
       );
    }

--- a/src/app/[locale]/(with-protected)/profile/edit/page.tsx
+++ b/src/app/[locale]/(with-protected)/profile/edit/page.tsx
@@ -1,19 +1,12 @@
 "use client";
 
-import ToastPopup from "@/components/common/ToastPopup";
 import ClientProfileTitle from "@/components/domain/profile/ClientProfileTitle";
 import ClientProfileUpdateForm from "@/components/domain/profile/ClientProfileUpdateForm";
 import MoverProfileUpdateForm from "@/components/domain/profile/MoverProfileUpdateForms";
 import { useAuth } from "@/context/AuthContext";
-import { useState } from "react";
 
 export default function EditProfilePage() {
    const { user } = useAuth();
-   const [toast, setToast] = useState<{
-      id: number;
-      text: string;
-      success: boolean;
-   } | null>(null);
 
    // ✅ 일반으로 로그인한 회원의 경우
    if (user?.userType === "client") {
@@ -28,16 +21,9 @@ export default function EditProfilePage() {
                   }
                >
                   <ClientProfileTitle type="수정" />
-                  <ClientProfileUpdateForm setToast={setToast} />
+                  <ClientProfileUpdateForm />
                </div>
             </div>
-            {toast && (
-               <ToastPopup
-                  key={toast.id}
-                  text={toast.text}
-                  success={toast.success}
-               />
-            )}
          </>
       );
    }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,7 +3,6 @@ import "../globals.css";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { routing } from "@/i18n/routing";
 import { notFound } from "next/navigation";
-import { Toaster } from "react-hot-toast";
 import { Providers } from "@/app/providers";
 import { ToastProvider } from "@/context/ToastConText";
 import ToastContainer from "@/components/common/ToastContainer";

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,8 @@ import { routing } from "@/i18n/routing";
 import { notFound } from "next/navigation";
 import { Toaster } from "react-hot-toast";
 import { Providers } from "@/app/providers";
+import { ToastProvider } from "@/context/ToastConText";
+import ToastContainer from "@/components/common/ToastContainer";
 
 export const metadata: Metadata = {
    title: "무빙 - 스마트한 이사 비교 플랫폼",
@@ -29,8 +31,10 @@ export default async function RootLayout({
          <body className="h-full min-h-screen">
             <NextIntlClientProvider>
                <Providers>
-                  <main>{children}</main>
-                  <Toaster position="top-center" />
+                  <ToastProvider>
+                     <main>{children}</main>
+                     <ToastContainer />
+                  </ToastProvider>
                </Providers>
             </NextIntlClientProvider>
          </body>

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -4,7 +4,6 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(req: NextRequest) {
    const token = req.nextUrl.searchParams.get("token");
    const error = req.nextUrl.searchParams.get("error");
-
    if (error) {
       return NextResponse.redirect(new URL(`/sign-in?error=${error}`, req.url));
    }

--- a/src/components/common/ToastContainer.tsx
+++ b/src/components/common/ToastContainer.tsx
@@ -1,0 +1,23 @@
+// 원래 있던 ToastPopup을 한 번 감싼 컴포넌트입니다.
+
+"use client";
+
+import React from "react";
+import ToastPopup from "./ToastPopup";
+import { useToast } from "@/context/ToastConText";
+
+export default function ToastContainer() {
+   const { toast } = useToast();
+
+   return (
+      <>
+         {toast && (
+            <ToastPopup
+               key={toast.id}
+               text={toast.text}
+               success={toast.success}
+            />
+         )}
+      </>
+   );
+}

--- a/src/components/domain/profile/ClientProfilePostForm.tsx
+++ b/src/components/domain/profile/ClientProfilePostForm.tsx
@@ -7,7 +7,6 @@ import SolidButton from "../../common/SolidButton";
 import { MOVE_TYPES, moveType, regions } from "@/constants";
 import useClientProfilePostForm from "@/lib/hooks/useClientProfilePostForm";
 import ImageInputField from "./ImageInputField";
-import { NotiSetting } from "@/lib/types";
 
 export default function ClientProfilePostForm() {
    // ✅ 함수 등 모음

--- a/src/components/domain/profile/ClientProfilePostForm.tsx
+++ b/src/components/domain/profile/ClientProfilePostForm.tsx
@@ -9,7 +9,7 @@ import useClientProfilePostForm from "@/lib/hooks/useClientProfilePostForm";
 import ImageInputField from "./ImageInputField";
 import { NotiSetting } from "@/lib/types";
 
-export default function ClientProfilePostForm({ setToast }: NotiSetting) {
+export default function ClientProfilePostForm() {
    // ✅ 함수 등 모음
    const {
       isValid,
@@ -21,7 +21,7 @@ export default function ClientProfilePostForm({ setToast }: NotiSetting) {
       control,
       errors,
       watch,
-   } = useClientProfilePostForm({ setToast });
+   } = useClientProfilePostForm();
 
    return (
       <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -12,13 +12,12 @@ import OutlinedButton from "@/components/common/OutlinedButton";
 import ImageInputField from "./ImageInputField";
 import { useAuth } from "@/context/AuthContext";
 import { ClientProfileUpdateValue } from "@/lib/schemas";
-import { NotiSetting } from "@/lib/types";
 import { useRouter } from "next/navigation";
 
 const style1 = "lg:mb-14 lg:flex-row lg:justify-between lg:gap-14";
 const borderStyle = "border-line-100 my-5 lg:my-8";
 
-export default function ClientProfileUpdateForm({ setToast }: NotiSetting) {
+export default function ClientProfileUpdateForm() {
    // ✅ 함수 등 모음
    const router = useRouter();
    const { user } = useAuth();
@@ -33,7 +32,7 @@ export default function ClientProfileUpdateForm({ setToast }: NotiSetting) {
       handleSubmit,
       watch,
       control,
-   } = useClientProfileUpdateForm({ setToast });
+   } = useClientProfileUpdateForm();
 
    return (
       <>

--- a/src/components/domain/request/FormWizard.tsx
+++ b/src/components/domain/request/FormWizard.tsx
@@ -10,6 +10,7 @@ import { CreateRequestDto, FormWizardState } from "@/lib/types";
 import { patchRequestDraft } from "@/lib/api/request/requests/requestDraftApi";
 import { debounce } from "lodash";
 import { createRequestAction } from "@/lib/actions/request.action";
+import ToastPopup from "@/components/common/ToastPopup";
 import { useFormWizard } from "@/context/FormWizardContext";
 import {
    useActiveRequest,
@@ -30,6 +31,12 @@ export default function FormWizard({}) {
       useFormWizard();
    const [formState, setFormState] = useState<FormWizardState>(defaultState);
    const [isInitialized, setIsInitialized] = useState(false);
+
+   const [toast, setToast] = useState<{
+      id: number;
+      text: string;
+      success: boolean;
+   } | null>(null);
 
    const isFormValid =
       !!formState.moveType &&
@@ -102,13 +109,21 @@ export default function FormWizard({}) {
       try {
          await createRequestAction(formState as CreateRequestDto);
 
-         showSuccess("견적 요청이 완료되었어요!"); // 성경 추가
+         setToast({
+            id: Date.now(),
+            text: "견적 요청이 완료되었어요!",
+            success: true,
+         });
 
          setCurrentStep(4);
       } catch (err) {
          console.error("견적 요청 실패:", err);
 
-         showError("이미 진행 중인 견적 요청이 있어요."); // 성경 추가
+         setToast({
+            id: Date.now(),
+            text: "이미 진행 중인 견적 요청이 있어요.",
+            success: false,
+         });
       }
    };
 

--- a/src/components/domain/request/FormWizard.tsx
+++ b/src/components/domain/request/FormWizard.tsx
@@ -10,7 +10,6 @@ import { CreateRequestDto, FormWizardState } from "@/lib/types";
 import { patchRequestDraft } from "@/lib/api/request/requests/requestDraftApi";
 import { debounce } from "lodash";
 import { createRequestAction } from "@/lib/actions/request.action";
-import ToastPopup from "@/components/common/ToastPopup";
 import { useFormWizard } from "@/context/FormWizardContext";
 import {
    useActiveRequest,
@@ -31,12 +30,6 @@ export default function FormWizard({}) {
       useFormWizard();
    const [formState, setFormState] = useState<FormWizardState>(defaultState);
    const [isInitialized, setIsInitialized] = useState(false);
-
-   const [toast, setToast] = useState<{
-      id: number;
-      text: string;
-      success: boolean;
-   } | null>(null);
 
    const isFormValid =
       !!formState.moveType &&
@@ -109,21 +102,13 @@ export default function FormWizard({}) {
       try {
          await createRequestAction(formState as CreateRequestDto);
 
-         setToast({
-            id: Date.now(),
-            text: "견적 요청이 완료되었어요!",
-            success: true,
-         });
+         showSuccess("견적 요청이 완료되었어요!"); // 성경 추가
 
          setCurrentStep(4);
       } catch (err) {
          console.error("견적 요청 실패:", err);
 
-         setToast({
-            id: Date.now(),
-            text: "이미 진행 중인 견적 요청이 있어요.",
-            success: false,
-         });
+         showError("이미 진행 중인 견적 요청이 있어요."); // 성경 추가
       }
    };
 

--- a/src/context/ToastConText.tsx
+++ b/src/context/ToastConText.tsx
@@ -1,0 +1,85 @@
+/**
+ * 사용법:
+ *
+ * showSuccess("로그인 성공!")
+ * showError("로그인 실패!")
+ * hideToast: 알림 보이다가 사라지게 하고 싶을 때
+ */
+
+"use client";
+
+import React, {
+   createContext,
+   useContext,
+   useState,
+   useCallback,
+   ReactNode,
+} from "react";
+
+interface Toast {
+   id: number;
+   text: string;
+   success: boolean;
+}
+
+interface ToastContextType {
+   toast: Toast | null;
+   showToast: (text: string, success?: boolean) => void;
+   showSuccess: (text: string) => void;
+   showError: (text: string) => void;
+   hideToast: () => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+   const [toast, setToast] = useState<Toast | null>(null);
+
+   const showToast = useCallback((text: string, success: boolean = true) => {
+      setToast({
+         id: Date.now(),
+         text,
+         success,
+      });
+   }, []);
+
+   const showSuccess = useCallback(
+      (text: string) => {
+         showToast(text, true);
+      },
+      [showToast],
+   );
+
+   const showError = useCallback(
+      (text: string) => {
+         showToast(text, false);
+      },
+      [showToast],
+   );
+
+   const hideToast = useCallback(() => {
+      setToast(null);
+   }, []);
+
+   return (
+      <ToastContext.Provider
+         value={{
+            toast,
+            showToast,
+            showSuccess,
+            showError,
+            hideToast,
+         }}
+      >
+         {children}
+      </ToastContext.Provider>
+   );
+}
+
+export function useToast() {
+   const context = useContext(ToastContext);
+   if (context === undefined) {
+      throw new Error("useToast는 ToastProvider 내부에서 사용해야 합니다.");
+   }
+   return context;
+}

--- a/src/lib/hooks/useAuthError.ts
+++ b/src/lib/hooks/useAuthError.ts
@@ -1,0 +1,28 @@
+// 일반 회원가입에서 쓴 이메일로 소셜 로그인하려고 할 때
+
+"use client";
+
+import { useToast } from "@/context/ToastConText";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function useAuthError() {
+   const searchParams = useSearchParams();
+   const router = useRouter();
+   const { showError } = useToast();
+
+   useEffect(() => {
+      const error = searchParams.get("error");
+      if (error) {
+         // URL에서 오류 메시지 디코딩하고 토스트 알림 표시
+         const decodedError = decodeURIComponent(error);
+         showError(decodedError);
+
+         // URL에서 error 파라미터 제거
+         const newUrl = new URL(location.href);
+         newUrl.searchParams.delete("error");
+         router.replace(newUrl.pathname, { scroll: false });
+      }
+      // 여기는 없지만 BE에서 로그인 페이지로 이동하게 처리해 둠
+   }, [searchParams, router, showError]);
+}

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -8,15 +8,17 @@ import { ClientProfilePostSchema, ClientProfilePostValue } from "../schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import updateProfileImage from "../api/auth/requests/updateProfileImage";
 import { AuthFetchError } from "../types";
-import { NotiSetting, ServiceType } from "../types/client.types";
+import { ServiceType } from "../types/client.types";
 import clientProfile from "../api/auth/requests/updateClientProfile";
 import { tokenSettings } from "../utils";
+import { useToast } from "@/context/ToastConText";
 
-export default function useClientProfilePostForm({ setToast }: NotiSetting) {
+export default function useClientProfilePostForm() {
    // ✅ 상태 모음
    const router = useRouter();
    const [isLoading, setIsLoading] = useState(false);
    const { refreshUser } = useAuth();
+   const { showSuccess } = useToast();
 
    // react-hook-form
    const {
@@ -87,11 +89,7 @@ export default function useClientProfilePostForm({ setToast }: NotiSetting) {
             }
 
             // 알림
-            setToast({
-               id: Date.now(),
-               text: "프로필이 등록되었습니다.",
-               success: true,
-            });
+            showSuccess("프로필이 수정되었습니다.");
 
             // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
             setTimeout(async () => {

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -11,14 +11,16 @@ import {
    updateClientProfileSchema,
 } from "../schemas";
 import clientProfile from "../api/auth/requests/updateClientProfile";
-import { NotiSetting, ServiceType } from "../types/client.types";
+import { ServiceType } from "../types/client.types";
 import updateProfileImage from "../api/auth/requests/updateProfileImage";
+import { useToast } from "@/context/ToastConText";
 
-export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
+export default function useClientProfileUpdateForm() {
    // ✅ 상태 모음
    const router = useRouter();
    const { user, refreshUser } = useAuth();
    const [isLoading, setIsLoading] = useState(false);
+   const { showSuccess } = useToast();
 
    // ✅ 초깃값 보존 용도 기본값
    function getInitialValues(user: User | null): ClientProfileUpdateValue {
@@ -115,12 +117,7 @@ export default function useClientProfileUpdateForm({ setToast }: NotiSetting) {
          };
 
          await clientProfile.update(payload);
-
-         setToast({
-            id: Date.now(),
-            text: "프로필이 수정되었습니다.",
-            success: true,
-         });
+         showSuccess("프로필이 수정되었습니다."); // 알림 모달
 
          // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
          setTimeout(async () => {

--- a/src/lib/types/client.types.ts
+++ b/src/lib/types/client.types.ts
@@ -20,8 +20,3 @@ export interface ClientProfileUpdateData<T extends FieldValues> {
    error?: string;
    social?: boolean;
 }
-
-// 토스트 알림
-export interface NotiSetting {
-   setToast: (toast: { id: number; text: string; success: boolean }) => void;
-}


### PR DESCRIPTION
## 작업 개요
- 토스트 알림 전역화하고 담당 페이지에 적용

---

## 작업 상세 내용
- [x] 토스트 알림 전역화하고 예전에 만들었던 페이지에 적용
- [x] 소셜 로그인 오류에 토스트 알림 적용 (기사 쪽도 함께 적용)

---

## 🗂️ 수정한 파일
- `src/app/[locale]/(with-guest)/sign-in/client/page.tsx`
- `src/app/[locale]/(with-protected)/profile/create/page.tsx`
- `src/app/[locale]/(with-protected)/profile/edit/page.tsx`
- `src/app/[locale]/layout.tsx`
- `src/components/domain/profile/ClientProfilePostForm.tsx`
- `src/components/domain/profile/ClientProfileUpdateForm.tsx`
- `src/lib/hooks/useClientProfilePostForm.ts`
- `src/lib/hooks/useClientProfileUpdateForm.ts`

---

## 🗂️ 새로 작성한 파일
- `src/components/common/ToastContainer.tsx`
- `src/context/ToastConText.tsx`
- `src/lib/hooks/useAuthError.ts`

---

## 기타 참고 사항
- 사용법: 알림 기능 사용해야 하는 컴포넌트에서 useToast()를 불러오고 `showSuccess("내용")`, `showError("내용")`으로 적용
