### PR TITLE
feat: 로그인 횟수 및 프로필 수정 시 비밀번호 재설정 횟수 제한 기능 추가

### DIFF
--- a/src/components/common/ProfileDropdownMenu.tsx
+++ b/src/components/common/ProfileDropdownMenu.tsx
@@ -52,16 +52,16 @@ export default function ProfileDropDownMenu() {
             ))}
          </ul>
          <div className="bg-line-100 h-0.25 w-full"></div>
-         <div className="text-14-regular lg:text-16-regular flex flex-col justify-center gap-1 pt-2 text-gray-500">
+         <div className="text-14-regular lg:text-16-regular flex flex-col justify-center gap-2 pt-2 text-gray-500">
             <button onClick={handleLogout} className="block w-full">
                {t("logout")}
             </button>
-
+            <hr className="border-line-200" />
             <button
                onClick={() => {
                   setIsWithdrawModalOpen(true);
                }}
-               className="block w-full"
+               className="text-secondary-red-200 block w-full underline"
             >
                {t("withdraw")}
             </button>

--- a/src/components/domain/auth/SignInForm.tsx
+++ b/src/components/domain/auth/SignInForm.tsx
@@ -14,8 +14,15 @@ interface Prop {
 
 export default function SignInForm({ userType }: Prop) {
    // ✅ 함수 모음
-   const { register, errors, isValid, onSubmit, isLoading, handleSubmit } =
-      useSignInForm();
+   const {
+      register,
+      errors,
+      isValid,
+      onSubmit,
+      isLoading,
+      handleSubmit,
+      isLoginBlock,
+   } = useSignInForm();
 
    return (
       <form
@@ -41,7 +48,10 @@ export default function SignInForm({ userType }: Prop) {
 
          {/* ✅ 로그인 버튼 */}
          <section className="mt-4 lg:mt-10">
-            <SolidButton type="submit" disabled={!isValid || isLoading}>
+            <SolidButton
+               type="submit"
+               disabled={!isValid || isLoading || isLoginBlock}
+            >
                {isLoading ? "로딩 중..." : "로그인"}
             </SolidButton>
             <div className="mt-4 flex items-center justify-center gap-1 lg:mt-8 lg:gap-2">

--- a/src/components/domain/profile/ClientProfileTitle.tsx
+++ b/src/components/domain/profile/ClientProfileTitle.tsx
@@ -34,7 +34,7 @@ export default function ClientProfileTitle({ type, error }: Prop) {
                   *이용 서비스는 중복 선택 가능하며, 언제든 수정 가능해요!
                </p>
             )}
-            <ErrorText error={error} position="left" />
+            {error && <ErrorText error={error} position="left" />}
          </section>
       );
    }
@@ -51,7 +51,7 @@ export default function ClientProfileTitle({ type, error }: Prop) {
                   *내가 사는 지역은 언제든 수정 가능해요!
                </p>
             )}
-            <ErrorText error={error} position="left" />
+            {error && <ErrorText error={error} position="left" />}
          </section>
       );
    }

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -113,7 +113,7 @@ export default function ClientProfileUpdateForm() {
                         />
                         <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
                         <ProfilePasswordInput<ClientProfileUpdateValue>
-                           label="새 비밀번호"
+                           label="새 비밀번호 확인"
                            name="newPasswordConfirmation"
                            placeholder="새로운 비밀번호를 다시 한번 입력해 주세요."
                            register={register}

--- a/src/components/domain/profile/ClientProfileUpdateForm.tsx
+++ b/src/components/domain/profile/ClientProfileUpdateForm.tsx
@@ -114,10 +114,10 @@ export default function ClientProfileUpdateForm() {
                         <hr className="border-line-100 my-5 lg:my-8 lg:w-160" />
                         <ProfilePasswordInput<ClientProfileUpdateValue>
                            label="새 비밀번호"
-                           name="newPassword"
+                           name="newPasswordConfirmation"
                            placeholder="새로운 비밀번호를 다시 한번 입력해 주세요."
                            register={register}
-                           error={errors.newPassword?.message}
+                           error={errors.newPasswordConfirmation?.message}
                         />
                         <hr className="border-line-100 my-5 lg:my-8 lg:hidden" />
                      </>

--- a/src/lib/hooks/useClientProfilePostForm.ts
+++ b/src/lib/hooks/useClientProfilePostForm.ts
@@ -89,7 +89,7 @@ export default function useClientProfilePostForm() {
             }
 
             // 알림
-            showSuccess("프로필이 수정되었습니다.");
+            showSuccess("프로필이 등록되었습니다.");
 
             // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
             setTimeout(async () => {

--- a/src/lib/hooks/useClientProfileUpdateForm.ts
+++ b/src/lib/hooks/useClientProfileUpdateForm.ts
@@ -20,7 +20,7 @@ export default function useClientProfileUpdateForm() {
    const router = useRouter();
    const { user, refreshUser } = useAuth();
    const [isLoading, setIsLoading] = useState(false);
-   const { showSuccess } = useToast();
+   const { showSuccess, showError } = useToast();
 
    // ✅ 초깃값 보존 용도 기본값
    function getInitialValues(user: User | null): ClientProfileUpdateValue {
@@ -117,7 +117,7 @@ export default function useClientProfileUpdateForm() {
          };
 
          await clientProfile.update(payload);
-         showSuccess("프로필이 수정되었습니다."); // 알림 모달
+         showSuccess("프로필이 수정되었습니다."); // 알림창
 
          // Toast 알림과 상태 안 겹치게 User 상태 즉각 반영
          setTimeout(async () => {
@@ -131,6 +131,12 @@ export default function useClientProfileUpdateForm() {
 
          // 서버 오류 처리
          const customError = error as AuthFetchError;
+         const message = customError?.body.message;
+
+         // 비밀번호 등 프로필 수정 횟수 초과 오류 -> 알림창
+         if (customError.status === 429) {
+            if (message) showError(message);
+         }
 
          if (customError?.status) {
             Object.entries(customError.body.data!).forEach(([key, message]) => {


### PR DESCRIPTION
## 작업 개요
- 로그인 및 프로필 수정 시 비밀번호 재설정 횟수 제한 기능 추가

---

## 작업 상세 내용
- [x] 자잘한 스타일 수정
- [x] 로그인 횟수 및 프로필 수정 시 비밀번호 재설정 횟수 제한 기능 추가

---

## 🗂️ 수정한 파일
- `src/components/common/ProfileDropdownMenu.tsx` (어차피 사라질 친구지만...)
- `src/components/domain/auth/SignInForm.tsx`
- `src/components/domain/profile/ClientProfileTitle.tsx`
- `src/components/domain/profile/ClientProfileUpdateForm.tsx`
- `src/lib/hooks/useClientProfileUpdateForm.ts`
- `src/lib/hooks/useSignInForm.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x
