### PR TITLE
 fix: ChatRoom 한글 입력 시 엔터 중복 입력/전송 문제 해결(with Apple)

### DIFF
--- a/src/components/layout/ChatRoom.tsx
+++ b/src/components/layout/ChatRoom.tsx
@@ -39,6 +39,18 @@ export default function ChatRoom() {
    const textareaRef = useRef<HTMLTextAreaElement>(null);
    const wasTypingRef = useRef(false);
 
+   //맥으로 보낸 경우 딜레이 해결
+   const [isComposing, setIsComposing] = useState(false);
+
+   const handleCompositionStart = () => {
+      setIsComposing(true);
+   };
+
+   const handleCompositionEnd = () => {
+      setIsComposing(false);
+   };
+   // 맥으로 보낸 경우 딜레이 해결 종료
+
    const { data: messages = [] } = useChatMessages(chatId, user?.id ?? "");
    const { mutate: leaveChatRoomMutate } = useLeaveChatRoom();
 
@@ -179,7 +191,7 @@ export default function ChatRoom() {
    };
 
    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (e.key === "Enter" && !e.shiftKey && !isComposing) {
          e.preventDefault();
          handleSend();
       }
@@ -399,6 +411,8 @@ export default function ChatRoom() {
                ref={textareaRef}
                value={input}
                onChange={(e) => setInput(e.target.value)}
+               onCompositionStart={handleCompositionStart}
+               onCompositionEnd={handleCompositionEnd}
                onKeyDown={handleKeyDown}
                rows={1}
                placeholder={


### PR DESCRIPTION
## 작업 개요
- Mac 환경에서 한글 입력 시 엔터 전송/입력 중복 문제 해결 (Apple IME)

---

## 작업 상세 내용
- [x] `compositionstart` / `compositionend` 이벤트로 IME 조합 상태 감지 로직 추가
- [x] 한글 입력 조합 중 엔터 전송 방지
- [x] 영어 입력 시 기존 동작 유지
- [x] ChatRoom.tsx 입력창 로직 수정

---

## 수정한 파일
- `src/components/layout/ChatRoom.tsx`




---

## 기타 참고 사항
- Windows 환경에서는 기존 동작과 동일
- iOS/모바일 환경은 지속적인 테스트 필요