### PR TITLE
fix: 기사님 프로필 이미지 크기 제한 및 기타 

### DIFF
--- a/src/components/domain/auth/PasswordInput.tsx
+++ b/src/components/domain/auth/PasswordInput.tsx
@@ -22,8 +22,11 @@ export default function PasswordInput<T extends FieldValues>({
    const toggleEyeIcon = () => setIsVisible((prev) => !prev);
 
    return (
-      <section className="flex w-full flex-col gap-2">
-         <label htmlFor={name} className="text-black-400 text-14-regular">
+      <section className="flex w-full flex-col gap-2 lg:gap-4">
+         <label
+            htmlFor={name}
+            className="text-black-400 text-14-regular lg:text-20-regular"
+         >
             {label}
          </label>
 

--- a/src/components/domain/profile/GeneralInputField.tsx
+++ b/src/components/domain/profile/GeneralInputField.tsx
@@ -11,6 +11,7 @@ function GeneralInputField<T extends Record<string, FieldValue>>({
    placeholder,
    register,
    error,
+   labelId,
 }: InputFieldProps<T>) {
    //아래 로직은 career의 경우에만 해당됨
    const inputRef = useRef<HTMLInputElement | null>(null);
@@ -41,12 +42,19 @@ function GeneralInputField<T extends Record<string, FieldValue>>({
    };
 
    return (
-      <div className="flex flex-col gap-2 leading-8">
-         <div className="text-16-semibold">
+      <div className="flex flex-col gap-4 leading-8">
+         <label
+            htmlFor={labelId}
+            className="text-16-semibold lg:text-20-semibold lg:mt-4"
+         >
             {text}
-            <span className="text-blue-300"> *</span>
-         </div>
+            <span className="text-blue-300" aria-hidden="true">
+               *
+            </span>
+         </label>
+
          <input
+            id={labelId}
             type="text"
             {...register?.(name)}
             ref={(el) => {
@@ -55,8 +63,10 @@ function GeneralInputField<T extends Record<string, FieldValue>>({
             }}
             onBlur={handleBlur}
             onFocus={handleFocus}
-            className={`bg-bg-200 w-full rounded-2xl px-4 py-3 placeholder:text-gray-300 ${error ? "border border-red-500" : ""}`}
+            className={`mg:h-13 bg-bg-200 mt-4 h-13 w-full rounded-2xl pl-3.5 placeholder:text-gray-300 lg:mb-4 lg:h-16 ${error ? "border border-red-500" : ""}`}
             placeholder={placeholder}
+            aria-describedby={error ? `${labelId}-error` : undefined}
+            aria-invalid={!!error}
          />
 
          <ErrorText error={error?.message} />

--- a/src/components/domain/profile/ImageEditModal.tsx
+++ b/src/components/domain/profile/ImageEditModal.tsx
@@ -174,7 +174,6 @@ export default function ImageEditModal({
             const maxRadius = Math.min(
                displayInfo.displayWidth / 2,
                displayInfo.displayHeight / 2,
-               MAX_RADIUS,
             );
 
             const newRadius = Math.min(

--- a/src/components/domain/profile/MoverProfilePostForms.tsx
+++ b/src/components/domain/profile/MoverProfilePostForms.tsx
@@ -35,15 +35,6 @@ export default function MoverProfilePostForm() {
 
          <div className="flex flex-col lg:flex-row lg:gap-18">
             <div className="flex flex-1 flex-col">
-               <GeneralInputField<MoverProfileInput>
-                  labelId="nickname-label"
-                  name="nickName"
-                  text="별명"
-                  placeholder="사이트에 노출될 이름을 입력해주세요"
-                  register={register}
-                  error={errors.nickName}
-               />
-
                <hr className="border-line-100 m-0 border-t p-0" />
 
                <ImageInputField
@@ -57,7 +48,7 @@ export default function MoverProfilePostForm() {
                <hr className="border-line-100 m-0 border-t p-0" />
 
                <GeneralInputField<MoverProfileInput>
-                  labelId="career-label"
+                  labelId="nickName-label"
                   name="nickName"
                   text={t("nickNameLabel")}
                   placeholder={t("nickNamePlaceholder")}
@@ -68,6 +59,7 @@ export default function MoverProfilePostForm() {
                <hr className="border-line-100 m-0 border-t p-0" />
 
                <GeneralInputField<MoverProfileInput>
+                  labelId="career-label"
                   name="career"
                   text={t("careerLabel")}
                   placeholder={t("careerPlaceholder")}

--- a/src/lib/utils/profile.util.ts
+++ b/src/lib/utils/profile.util.ts
@@ -18,6 +18,19 @@ export const labelToEnumMap = Object.fromEntries(
    Object.entries(serviceTypeMap).map(([key, value]) => [value, key]),
 );
 
+// (프로필 이미지 등록/수정 시) 크롭된 이미지(base64:string)를 File로 변환
+export function base64ToFile(base64: string, filename: string): File {
+   const arr = base64.split(",");
+   const mime = arr[0].match(/:(.*?);/)![1];
+   const bstr = atob(arr[1]);
+   let n = bstr.length;
+   const u8arr = new Uint8Array(n);
+   while (n--) {
+      u8arr[n] = bstr.charCodeAt(n);
+   }
+   return new File([u8arr], filename, { type: mime });
+}
+
 // (프로필 이미지 수정 시) 크롭 원이 이미지를 벗어나지 않도록
 export function getImageDisplayInfo(img: HTMLImageElement, container: DOMRect) {
    const imageAspect = img.naturalWidth / img.naturalHeight;


### PR DESCRIPTION
## 작업 개요
- 기본 배포용 구조 세팅 및 전역 스타일 적용

---

## 작업 상세 내용
- [x] 이미지 용량 에러 메세지 띄우기 (10MB)
- [x] 공통, 비밀번호 input 스타일 돌려놓기
- [x] 크롭 사이즈 조절 가능하게 수정

---

## 🗂️ 수정한 파일
- `src/components/domain/auth/PasswordInput.tsx`
- `src/components/domain/profile/GeneralInputField.tsx`
- `src/components/domain/profile/ImageEditModal.tsx`
- `src/components/domain/profile/MoverProfilePostForms.tsx`
- `src/lib/hooks/useMoverProfileUpdateForm.ts`
- `src/lib/utils/profile.util.ts`

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항
