### PR TITLE
feat: 채팅 메시지 내 URL 자동 링크 처리 및 UserWithdrawal 인라인 리팩토링

### DIFF
--- a/src/components/common/MessageText.tsx
+++ b/src/components/common/MessageText.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+
+/** 내부/외부 링크를 자동으로 감지해 Link 또는 <a>로 렌더링 */
+export default function MessageText({
+   text,
+   className = "",
+   linkClassName = "underline break-all hover:opacity-80",
+}: {
+   text: string;
+   className?: string;
+   linkClassName?: string;
+}) {
+   const nodes = React.useMemo(
+      () => linkifyText(text, linkClassName),
+      [text, linkClassName],
+   );
+   return <span className={className}>{nodes}</span>;
+}
+
+/** 텍스트 내 URL/경로를 찾아 React 노드 배열로 변환 */
+function linkifyText(text: string, linkClassName: string): React.ReactNode[] {
+   const parts: React.ReactNode[] = [];
+   // http(s), www., /로 시작하는 내부 경로 포함
+   const urlRegex =
+      /(https?:\/\/[^\s]+|www\.[^\s]+|\/[A-Za-z0-9\-._~%/?#[\]@!$&'()*+,;=]+)/g;
+
+   let lastIndex = 0;
+   let match: RegExpExecArray | null;
+
+   while ((match = urlRegex.exec(text)) !== null) {
+      const raw = match[0];
+
+      if (match.index > lastIndex) {
+         parts.push(text.slice(lastIndex, match.index));
+      }
+
+      parts.push(renderLinkNode(raw, linkClassName, parts.length));
+      lastIndex = match.index + raw.length;
+   }
+
+   if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+   return parts;
+}
+
+function renderLinkNode(raw: string, linkClassName: string, keySeed: number) {
+   const base =
+      typeof window !== "undefined"
+         ? window.location.origin
+         : "http://localhost";
+   const href = raw.startsWith("www.") ? `https://${raw}` : raw;
+
+   let url: URL | null = null;
+   try {
+      url = new URL(href, base); // 상대경로도 처리
+   } catch {
+      return raw; // URL 파싱 실패 시 원문 그대로
+   }
+
+   // 동일 오리진 => 내부 라우팅 (Next Link)
+   if (typeof window !== "undefined" && url.origin === window.location.origin) {
+      const internalPath = `${url.pathname}${url.search}${url.hash}`;
+      return (
+         <Link
+            key={`in-${keySeed}`}
+            href={internalPath}
+            className={linkClassName}
+         >
+            {raw}
+         </Link>
+      );
+   }
+
+   // 외부 링크 => 새 탭
+   return (
+      <a
+         key={`out-${keySeed}`}
+         href={url.href}
+         target="_blank"
+         rel="noopener noreferrer"
+         className={linkClassName}
+      >
+         {raw}
+      </a>
+   );
+}

--- a/src/components/common/UserWithdrawal.tsx
+++ b/src/components/common/UserWithdrawal.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import React from "react";
-import { useUserWithdrawForm } from "@/lib/hooks/useUserWithdrawForm";
+import Image from "next/image";
+import openedEye from "@/assets/images/visibilityIcon.svg";
+import closedEye from "@/assets/images/visibilityOffIcon.svg";
 import SolidButton from "./SolidButton";
 import OutlinedButton from "./OutlinedButton";
-import PasswordInput from "../domain/auth/PasswordInput";
-import GeneralInputField from "../domain/profile/GeneralInputField";
 import { useAuth } from "@/context/AuthContext";
 import { useTranslations } from "next-intl";
+import { useUserWithdrawForm } from "@/lib/hooks/useUserWithdrawForm";
+import ErrorText from "../domain/auth/ErrorText";
 
 export function UserWithdrawal({ onClose }: { onClose: () => void }) {
    const t = useTranslations("Header");
@@ -15,6 +17,8 @@ export function UserWithdrawal({ onClose }: { onClose: () => void }) {
 
    const { register, errors, isValid, isLoading, handleSubmit, onSubmit } =
       useUserWithdrawForm(onClose);
+
+   const [isPwVisible, setIsPwVisible] = React.useState(false);
 
    if (!user) return null;
 
@@ -26,31 +30,90 @@ export function UserWithdrawal({ onClose }: { onClose: () => void }) {
       <div className="flex h-full flex-col p-4">
          <h2 className="text-18-semibold lg:text-22-semibold">회원탈퇴</h2>
 
-         {/* 내용 */}
          <form
             onSubmit={handleSubmit((data) => onSubmit(userType)(data))}
             className="flex h-full flex-col justify-between py-4"
          >
-            <div className="">
+            <div>
                {isLocal ? (
-                  <>
-                     <PasswordInput
-                        name="password"
-                        placeholder={t("passwordPlaceholder")}
-                        register={register}
+                  // ===== 인라인 PasswordInput =====
+                  <section className="flex w-full flex-col gap-2">
+                     {/* label은 옵션이었으나 props 없이 그대로 유지 */}
+                     <label
+                        htmlFor="password"
+                        className="text-14-regular text-gray-900"
+                     >
+                        계정의 비밀번호를 입력해 주세요
+                     </label>
+
+                     <div className="relative w-full">
+                        <input
+                           id="password"
+                           type={isPwVisible ? "text" : "password"}
+                           placeholder={t("passwordPlaceholder")}
+                           {...register("password")}
+                           aria-invalid={!!errors.password}
+                           aria-describedby={
+                              errors.password ? "password-error" : undefined
+                           }
+                           className={`${
+                              errors.password
+                                 ? "border-secondary-red-200 focus:border-secondary-red-200"
+                                 : "border-line-200 focus:border-primary-blue-300"
+                           } text-black-400 h-14 w-full rounded-2xl border bg-white p-3.5 lg:h-16`}
+                        />
+
+                        <button
+                           type="button"
+                           onClick={() => setIsPwVisible((v) => !v)}
+                           aria-label={
+                              isPwVisible
+                                 ? "비밀번호 숨김 모드"
+                                 : "비밀번호 보기 모드"
+                           }
+                           className="absolute top-1/2 right-3 -translate-y-1/2"
+                        >
+                           <Image
+                              src={isPwVisible ? openedEye : closedEye}
+                              alt=""
+                              priority
+                              width={24}
+                              height={24}
+                           />
+                        </button>
+                     </div>
+
+                     <ErrorText
                         error={errors.password?.message}
+                        name="password"
                      />
-                  </>
+                  </section>
                ) : (
-                  <>
-                     <GeneralInputField
-                        name="confirmMessage"
-                        text={t("confirmMessageLabel")}
+                  // ===== 인라인 GeneralInputField (confirmMessage 전용) =====
+                  <div className="flex flex-col gap-2 leading-8">
+                     <div className="text-16-semibold">
+                        {t("confirmMessageLabel")}
+                        <span className="text-blue-300"> *</span>
+                     </div>
+
+                     <input
+                        id="confirmMessage"
+                        type="text"
                         placeholder={t("confirmMessagePlaceholder")}
-                        register={register}
-                        error={errors.confirmMessage}
+                        {...register("confirmMessage")}
+                        className={`bg-bg-200 w-full rounded-2xl px-4 py-3 placeholder:text-gray-300 ${
+                           errors.confirmMessage ? "border border-red-500" : ""
+                        }`}
+                        aria-invalid={!!errors.confirmMessage}
+                        aria-describedby={
+                           errors.confirmMessage
+                              ? "confirmMessage-error"
+                              : undefined
+                        }
                      />
-                  </>
+
+                     <ErrorText error={errors.confirmMessage?.message} />
+                  </div>
                )}
             </div>
 

--- a/src/components/layout/ChatRoom.tsx
+++ b/src/components/layout/ChatRoom.tsx
@@ -23,6 +23,7 @@ import { IoIosSend } from "react-icons/io";
 import { FiLogOut } from "react-icons/fi";
 import { useOutsideClick } from "@/lib/hooks/useOutsideClick";
 import { ChatMessage, ChatParticipant, ParticipantsMap } from "@/lib/types";
+import MessageText from "../common/MessageText";
 
 dayjs.locale("ko");
 
@@ -260,7 +261,7 @@ export default function ChatRoom() {
                   }`}
                   style={{ wordBreak: "break-all" }}
                >
-                  {msg.text}
+                  <MessageText text={msg.text} />
                </div>
 
                <div


### PR DESCRIPTION
## 작업 개요
- 채팅 메시지 내 URL 자동 링크 처리 및 UserWithdrawal 인라인 리팩토링


---

## 작업 상세 내용
- [x] MessageText 컴포넌트 추가하여 채팅 메시지 내 URL을 자동으로 링크로 변환
  - 내부 링크는 Next.js Link로 처리
  - 외부 링크는 새 탭에서 열림
  - 일반 텍스트는 기존 그대로 출력
- [x] ChatRoom에 MessageText 적용하여 URL 클릭 시 이동 가능
- [x] UserWithdrawal에서 PasswordInput / GeneralInputField를 제거하고 인라인 형태로 리팩토링

---

## 🗂️ 수정한 파일
- `src/components/common/UserWithdrawal.tsx`
- `src/components/layout/ChatRoom.tsx`
---

## 🗂️ 새로 작성한 파일
- `src/components/common/MessageText.tsx`

---

## 기타 참고 사항
- URL 처리 로직은 XSS 방지를 위해 토큰화 방식으로 구현
- 너무 긴 URL도 `break-all`로 줄바꿈 처리
- `www.`로 시작하는 경우 자동으로 `https://` 프로토콜 보정
