### PR TITLE
refactor: 받은 요청 목록 페이지 스피너 위치 오류 수정

### DIFF
--- a/src/components/domain/received-requests/ReceivedRequestsList.tsx
+++ b/src/components/domain/received-requests/ReceivedRequestsList.tsx
@@ -77,7 +77,11 @@ export default function ReceivedRequestsList({
          </div>
          <div className="py-4">
             <p ref={observerRef} />
-            {isFetchingNextPage && <SearchSpinner />}
+            {isFetchingNextPage && (
+               <div className="flex w-full justify-center">
+                  <SearchSpinner />
+               </div>
+            )}
             {!hasNextPage && (
                <p className="text-center text-gray-400">
                   {t("noMoreRequests")}

--- a/src/components/domain/received-requests/RequestCard.tsx
+++ b/src/components/domain/received-requests/RequestCard.tsx
@@ -75,7 +75,7 @@ export default function RequestCard({ req }: { req: ReceivedRequest }) {
          >
             <div className="border-line-100 flex flex-col rounded-2xl border px-3.5 py-4 lg:px-6 lg:py-5">
                <div className="flex items-center justify-between">
-                  <div className="item-center flex gap-2">
+                  <div className="item-center flex gap-1">
                      <MoveChip type={(req.moveType as ChipType) ?? "PENDING"} />
                      {req.isDesignated && <MoveChip type="DESIGNATED" />}
                   </div>


### PR DESCRIPTION
## 작업 개요
- 받은 요청 목록(ReceivedRequestsList) 페이지에서 스피너 위치가 어긋나는 문제 수정


---

## 작업 상세 내용
- [x] 스피너 위치를 중앙 정렬로 수정하여 UI 일관성 확보

---

## 🗂️ 수정한 파일
- `src/components/domain/received-requests/ReceivedRequestsList.tsx`
- `src/components/domain/received-requests/RequestCard.tsx`




