### PR TITLE
refactor: multer-s3에서 cloudinary로 리펙터링

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
    images: {
-      domains: ["www.zimssa.com", "i.imgur.com"], // 외부 이미지 호스트 허용
+      domains: ["www.zimssa.com", "i.imgur.com", "res.cloudinary.com"], // 외부 이미지 호스트 허용
       remotePatterns: [
          // next/image가 외부 s3 이미지 url을 허용하도록
          {

--- a/src/lib/api/auth/requests/updateProfileImage.ts
+++ b/src/lib/api/auth/requests/updateProfileImage.ts
@@ -1,6 +1,6 @@
 import { tokenFetch } from "@/lib/utils";
 
-// 기사님 프로필 이미지 생성,수정
+// 기사님 프로필 이미지 생성,수정 (AWS)
 export default async function updateProfileImage(formdata: FormData) {
    const url = "/images/upload?access=public";
 
@@ -11,3 +11,22 @@ export default async function updateProfileImage(formdata: FormData) {
 
    return res;
 }
+
+// 기사님 프로필 이미지 생성,수정 (cloudinary)
+export const uploadToCloudinary = async (file: File) => {
+   const formData = new FormData();
+   formData.append("file", file);
+   formData.append("upload_preset", "moving_users_profile");
+
+   // Cloudinary API 엔드포인트
+   const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUD_NAME;
+   const url = `https://api.cloudinary.com/v1_1/${CLOUD_NAME}/image/upload`;
+
+   const response = await fetch(url, {
+      method: "POST",
+      body: formData,
+   });
+
+   const data = await response.json();
+   return data;
+};

--- a/src/lib/hooks/useMoverProfilePostForm.ts
+++ b/src/lib/hooks/useMoverProfilePostForm.ts
@@ -10,9 +10,7 @@ import {
    useMoverProfileSchemas,
 } from "../schemas/profile.schema";
 import updateMoverProfile from "../api/auth/requests/updateMoverProfile";
-import updateProfileImage, {
-   uploadToCloudinary,
-} from "../api/auth/requests/updateProfileImage";
+import { uploadToCloudinary } from "../api/auth/requests/updateProfileImage";
 import { useAuth } from "@/context/AuthContext";
 import { tokenSettings } from "../utils";
 import { useTranslations } from "next-intl";

--- a/src/lib/hooks/useMoverProfilePostForm.ts
+++ b/src/lib/hooks/useMoverProfilePostForm.ts
@@ -10,7 +10,9 @@ import {
    useMoverProfileSchemas,
 } from "../schemas/profile.schema";
 import updateMoverProfile from "../api/auth/requests/updateMoverProfile";
-import updateProfileImage from "../api/auth/requests/updateProfileImage";
+import updateProfileImage, {
+   uploadToCloudinary,
+} from "../api/auth/requests/updateProfileImage";
 import { useAuth } from "@/context/AuthContext";
 import { tokenSettings } from "../utils";
 import { useTranslations } from "next-intl";
@@ -59,10 +61,16 @@ function useMoverProfilePostForm() {
                setIsLoading(false);
                return;
             }
-            const formData = new FormData();
-            formData.append("image", file);
-            const res = await updateProfileImage(formData);
-            imageUrl = res.url; // 백엔드에서 반환한 s3 URL
+
+            // Cloudinary 직접 업로드
+            const uploadResult = await uploadToCloudinary(file);
+            imageUrl = uploadResult.secure_url;
+
+            // AWS s3의 경우
+            //   const formData = new FormData();
+            // formData.append("image", file);
+            // const res = await updateProfileImage(formData);
+            // imageUrl = res.url; // 백엔드에서 반환한 s3 URL
          }
 
          // 이미지 처리 후 나머지 데이터 처리

--- a/src/lib/hooks/useMoverProfileUpdateForm.ts
+++ b/src/lib/hooks/useMoverProfileUpdateForm.ts
@@ -12,7 +12,9 @@ import {
 import { useAuth } from "@/context/AuthContext";
 import { base64ToFile, extractRegionNames } from "../utils/profile.util";
 import updateMoverProfile from "../api/auth/requests/updateMoverProfile";
-import updateProfileImage from "../api/auth/requests/updateProfileImage";
+import updateProfileImage, {
+   uploadToCloudinary,
+} from "../api/auth/requests/updateProfileImage";
 import { useTranslations } from "next-intl";
 import { useToast } from "@/context/ToastConText";
 import { updateUserProfileInChats } from "../firebase/firebaseChat";
@@ -87,10 +89,16 @@ function useMoverProfileUpdateForm() {
                setIsLoading(false);
                return;
             }
-            const formData = new FormData();
-            formData.append("image", file);
-            const res = await updateProfileImage(formData);
-            imageUrl = res.url; // 백엔드에서 반환한 s3 URL
+
+            // Cloudinary 직접 업로드
+            const uploadResult = await uploadToCloudinary(file);
+            imageUrl = uploadResult.secure_url;
+
+            // //AWS로 업로드
+            // const formData = new FormData();
+            // formData.append("image", file);
+            // const res = await updateProfileImage(formData);
+            // imageUrl = res.url; // 백엔드에서 반환한 s3 URL
          }
 
          // 이미지 처리 후 나머지 데이터 처리

--- a/src/lib/hooks/useMoverProfileUpdateForm.ts
+++ b/src/lib/hooks/useMoverProfileUpdateForm.ts
@@ -12,9 +12,7 @@ import {
 import { useAuth } from "@/context/AuthContext";
 import { base64ToFile, extractRegionNames } from "../utils/profile.util";
 import updateMoverProfile from "../api/auth/requests/updateMoverProfile";
-import updateProfileImage, {
-   uploadToCloudinary,
-} from "../api/auth/requests/updateProfileImage";
+import { uploadToCloudinary } from "../api/auth/requests/updateProfileImage";
 import { useTranslations } from "next-intl";
 import { useToast } from "@/context/ToastConText";
 import { updateUserProfileInChats } from "../firebase/firebaseChat";


### PR DESCRIPTION
## 작업 개요
- multer-s3에서 cloudinary로 리펙터링

---

## 작업 상세 내용
- [x] multer-s3에서 cloudinary로 리펙터링
---

## 🗂️ 수정한 파일
- `src/lib/api/auth/requests/updateProfileImage.ts`
- `src/lib/hooks/useMoverProfilePostForm.ts`
- `src/lib/hooks/useMoverProfileUpdateForm.ts`
- `next.config.ts`
- `src/lib/hooks/useClientProfilePostForm.ts`
- `src/lib/hooks/useClientProfileUpdateForm.ts`
---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항
- 프론트 env 파일에 NEXT_PUBLIC_CLOUD_NAME 변수 하나 추가하셔야합니다
