### PR TITLE
refactor: 기사님 표시 필드를 nickname으로 통일

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
             "jose": "^6.0.12",
             "lodash": "^4.17.21",
             "lottie-react": "^2.4.1",
-            "lucide-react": "^0.540.0",
             "next": "15.3.4",
             "next-intl": "^4.3.4",
             "nodemailer": "^7.0.5",
@@ -8193,15 +8192,6 @@
          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
          "license": "ISC"
-      },
-      "node_modules/lucide-react": {
-         "version": "0.540.0",
-         "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.540.0.tgz",
-         "integrity": "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ==",
-         "license": "ISC",
-         "peerDependencies": {
-            "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-         }
       },
       "node_modules/magic-string": {
          "version": "0.30.17",

--- a/src/app/[locale]/(with-protected)/my-quotes/client/[id]/page.tsx
+++ b/src/app/[locale]/(with-protected)/my-quotes/client/[id]/page.tsx
@@ -58,7 +58,7 @@ export default function ClientEstimatesDetailPage({
                   <MoverProfileclient
                      moveType={data.request.moveType}
                      isDesignated={false}
-                     moverName={data.mover.name}
+                     moverName={data.mover.nickName}
                      profileImage={data.mover.profileImage}
                      isFavorited={data.isFavorite}
                      averageReviewRating={data.mover.averageReviewRating}

--- a/src/components/common/MoverProfile.tsx
+++ b/src/components/common/MoverProfile.tsx
@@ -39,8 +39,6 @@ export default function MoverProfile({
 }: MoverProfileProps) {
    const t = useTranslations("Reviews");
 
-   console.log(nickName);
-
    const isBig = big && !forceMobileStyle;
 
    const containerClass = [

--- a/src/components/common/MoverProfile.tsx
+++ b/src/components/common/MoverProfile.tsx
@@ -39,6 +39,8 @@ export default function MoverProfile({
 }: MoverProfileProps) {
    const t = useTranslations("Reviews");
 
+   console.log(nickName);
+
    const isBig = big && !forceMobileStyle;
 
    const containerClass = [

--- a/src/components/common/ProfileDropdownMenu.tsx
+++ b/src/components/common/ProfileDropdownMenu.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/context/AuthContext";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { useRouter } from "next/navigation";
+import { Mover } from "@/lib/types";
 
 export default function ProfileDropDownMenu() {
    const t = useTranslations("Header");
@@ -33,7 +34,8 @@ export default function ProfileDropDownMenu() {
    return (
       <div className="border-line-200 absolute top-10 left-1/2 z-10 h-auto min-w-38 -translate-x-1/2 rounded-2xl border-1 bg-white px-4 py-2.5 text-nowrap lg:top-12 lg:min-w-50">
          <h2 className="text-16-semibold lg:text-18-semibold py-2 lg:py-2.5">
-            {user!.name} {honorific}
+            {user?.userType === "client" ? user.name : (user as Mover).nickName}{" "}
+            {honorific}
          </h2>
          <ul>
             {menuItems.map(({ label, href }) => (

--- a/src/components/domain/dashboard/MoverCard.tsx
+++ b/src/components/domain/dashboard/MoverCard.tsx
@@ -182,7 +182,10 @@ export default function MoverCard() {
                <div className="block lg:hidden">{profileImage}</div>
                <div className="flex-1 lg:space-y-2">
                   <p className="font-semibold lg:text-2xl">
-                     {mover.nickName || mover.name || ""}
+                     {mover.name}
+                     <span className="text-12-medium lg:text-14-medium text-gray-400">
+                        ({mover.nickName})
+                     </span>
                   </p>
                   <p className="text-sm font-normal text-gray-400 lg:text-xl">
                      {mover.introduction || t("noIntro")}

--- a/src/components/domain/my-quotes/Pending.tsx
+++ b/src/components/domain/my-quotes/Pending.tsx
@@ -49,7 +49,7 @@ export default function Pending() {
                      <MoverProfileclient
                         moveType={request.moveType as ChipType}
                         isDesignated={estimate.isDesignated}
-                        moverName={estimate.moverName}
+                        moverName={estimate.moverNickName}
                         profileImage={estimate.profileImage || profile}
                         isFavorited={!!estimate.isFavorited}
                         moverId={estimate.moverId}

--- a/src/components/domain/my-quotes/ReceivedCard.tsx
+++ b/src/components/domain/my-quotes/ReceivedCard.tsx
@@ -34,7 +34,7 @@ export default function ReceivedCard({
             isDesignated={designated.some(
                (d) => d.moverId === estimate.moverId,
             )}
-            moverName={estimate.moverName}
+            moverName={estimate.moverNickName}
             profileImage={estimate.profileImage}
             isFavorited={!!estimate.isFavorited}
             averageReviewRating={estimate.reviewRating}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,6 +22,7 @@ import { routing } from "@/i18n/routing"; // locales 배열 접근용
 import { useLocale, useTranslations } from "next-intl";
 import { useNotification } from "@/context/NotificationContext";
 import { useNotificationsQuery } from "@/lib/api/notification/query";
+import { Mover } from "@/lib/types";
 
 function getPathnameWithoutLocale(
    pathname: string,
@@ -270,7 +271,10 @@ export default function Header({ children }: { children?: React.ReactNode }) {
                         {isProfileDropDownOpen && <ProfileDropDownMenu />}
                      </div>
                      <span className="text-18-medium hidden lg:block">
-                        {user.name}
+                        {user.userType === "client"
+                           ? user.name
+                           : (user as Mover).nickName?.trim() ||
+                             t("loginMover")}
                         {t("honorific")}
                      </span>
                   </div>


### PR DESCRIPTION
## 작업 개요
- 기사님 표시 필드를 `name`에서 `nickname`으로 통일하여 사용자 혼란을 방지
- 모든 관련 컴포넌트 및 페이지에서 일관된 표기를 유지

---

## 작업 상세 내용
- [x] `MoverProfile`에서 name → nickname으로 수정
- [x] `Pending`, `ReceivedCard`, `MoverCard` 등 my-quotes 관련 컴포넌트 수정
- [x] `ProfileDropdownMenu`, `Header` 등 전역 컴포넌트 수정
---

## 🗂️ 수정한 파일
- `src/app/[locale]/(with-protected)/my-quotes/client/[id]/page.tsx`
- `src/components/common/MoverProfile.tsx`
- `src/components/common/ProfileDropdownMenu.tsx`
- `src/components/domain/dashboard/MoverCard.tsx`
- `src/components/domain/my-quotes/Pending.tsx`
- `src/components/domain/my-quotes/ReceivedCard.tsx`
- `src/components/layout/Header.tsx`
---



## 기타 참고 사항
- `nickname`이 비어있을 경우 기본값 `"기사님"`으로 표기
- 전역적으로 동일 규칙을 적용하여 추후 유지보수 시 혼란 방지
